### PR TITLE
Fix Heap::GetInstances for Android 9

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -131,6 +131,15 @@ function _getApi () {
 
       '_ZN3art2gc4Heap12VisitObjectsEPFvPNS_6mirror6ObjectEPvES5_': ['art::gc::Heap::VisitObjects', 'void', ['pointer', 'pointer', 'pointer']],
       '_ZN3art2gc4Heap12GetInstancesERNS_24VariableSizedHandleScopeENS_6HandleINS_6mirror5ClassEEEiRNSt3__16vectorINS4_INS5_6ObjectEEENS8_9allocatorISB_EEEE': ['art::gc::Heap::GetInstances', 'void', ['pointer', 'pointer', 'pointer', 'int', 'pointer']],
+      
+      // Android >= 9
+      '_ZN3art2gc4Heap12GetInstancesERNS_24VariableSizedHandleScopeENS_6HandleINS_6mirror5ClassEEEbiRNSt3__16vectorINS4_INS5_6ObjectEEENS8_9allocatorISB_EEEE':  function (address) {
+        const getInstances = new NativeFunction(address, 'void', ['pointer', 'pointer', 'pointer', 'bool', 'int', 'pointer'], nativeFunctionOptions);
+        this['art::gc::Heap::GetInstances'] = function (instance, scope, hClass, maxCount, instances) {
+          const useIsAssignableFrom = 0;
+          getInstances(instance, scope, hClass, useIsAssignableFrom, maxCount, instances);
+        };
+      },
 
       // Android < 6 for cloneArtMethod()
       '_ZN3art6Thread14CurrentFromGdbEv': ['art::Thread::CurrentFromGdb', 'pointer', []],
@@ -169,7 +178,8 @@ function _getApi () {
       '_ZN3art22IndirectReferenceTable3AddEjPNS_6mirror6ObjectE',
       '_ZN3art22IndirectReferenceTable3AddENS_15IRTSegmentStateENS_6ObjPtrINS_6mirror6ObjectEEE',
       '_ZN3art2gc4Heap12VisitObjectsEPFvPNS_6mirror6ObjectEPvES5_',
-      '_ZN3art2gc4Heap12GetInstancesERNS_24VariableSizedHandleScopeENS_6HandleINS_6mirror5ClassEEEiRNSt3__16vectorINS4_INS5_6ObjectEEENS8_9allocatorISB_EEEE'
+      '_ZN3art2gc4Heap12GetInstancesERNS_24VariableSizedHandleScopeENS_6HandleINS_6mirror5ClassEEEiRNSt3__16vectorINS4_INS5_6ObjectEEENS8_9allocatorISB_EEEE',
+      '_ZN3art2gc4Heap12GetInstancesERNS_24VariableSizedHandleScopeENS_6HandleINS_6mirror5ClassEEEbiRNSt3__16vectorINS4_INS5_6ObjectEEENS8_9allocatorISB_EEEE'
     ]
   }] : [{
     module: vmModule.path,


### PR DESCRIPTION
Fixes https://github.com/frida/frida-java/issues/94

Confirmed to work on Android 8 and Android 9.

![image](https://user-images.githubusercontent.com/4643257/52225152-08480600-28aa-11e9-8213-04ed75998d4f.png)

![image](https://user-images.githubusercontent.com/4643257/52225091-e51d5680-28a9-11e9-89a7-0c47359b39c2.png)
