### PR TITLE
Fix for Issue #139 and Issue #143

### DIFF
--- a/lib/class-factory.js
+++ b/lib/class-factory.js
@@ -1177,9 +1177,6 @@ function ClassFactory (vm) {
             if (jsType === STATIC_FIELD)
               return protoField;
 
-            if (this.$handle === undefined)
-              throw new Error('Unable to access instance field without an instance');
-
             const field = {};
 
             Object.defineProperties(field, {

--- a/lib/env.js
+++ b/lib/env.js
@@ -883,10 +883,6 @@ Env.prototype.getTypeName = function (type, getGenericsInformation) {
       this.deleteLocalRef(rawType);
     }
 
-    if (result === 'java.lang.Class' && !getGenericsInformation) {
-      return this.getActualTypeArgument(type);
-    }
-
     if (getGenericsInformation) {
       result += '<' + this.getActualTypeArgument(type) + '>';
     }

--- a/test/re/frida/ClassRegistryTest.java
+++ b/test/re/frida/ClassRegistryTest.java
@@ -63,6 +63,21 @@ public class ClassRegistryTest {
         assertEquals("name=Joe", script.getNextMessage());
     }
 
+    // Issue #139
+    @Test
+    public void classWrapperShouldBeJavaLangClass() throws ClassNotFoundException, InstantiationException, IllegalAccessException, IOException {
+        loadScript("var clazz = Java.use('java.lang.Class');" +
+                "send(clazz.class.$className);" +
+                "send(clazz.getClassLoader.overloads.length);" +
+                "clazz = Java.use('java.lang.Exception').$new().getClass();" +
+                "send(clazz.class.$className);" +
+                "send(clazz.getClassLoader.overloads.length);");
+        assertEquals("java.lang.Class", script.getNextMessage());
+        assertEquals("1", script.getNextMessage());
+        assertEquals("java.lang.Class", script.getNextMessage());
+        assertEquals("1", script.getNextMessage());
+    }
+
     private Script script = null;
 
     private void loadScript(String code) {

--- a/test/re/frida/MethodTest.java
+++ b/test/re/frida/MethodTest.java
@@ -272,12 +272,34 @@ public class MethodTest {
     @Test
     public void genericArrayTypeShouldConvertToArray() {
         loadScript("var GenericArray = Java.use('re.frida.GenericArray');" +
-            "var genericArray = GenericArray.getArray();" +
-            "send(Array.isArray(genericArray) + ',' + genericArray.length);");
+                "var genericArray = GenericArray.getArray();" +
+                "send(Array.isArray(genericArray) + ',' + genericArray.length);");
         assertEquals("true,2", script.getNextMessage());
     }
 
-    private Script script = null;
+    // Issue #143
+    @Test
+    public void instanceFieldAttributeCanBeRead() {
+        loadScript("var Cipher = Java.use('javax.crypto.Cipher');" +
+                "send('' + Cipher.provider.fieldType);" +
+                "send('' + Cipher.provider.fieldReturnType.className);");
+        assertEquals("2", script.getNextMessage());
+        assertEquals("java.security.Provider", script.getNextMessage());
+    }
+
+    // Issue #143
+    @Test
+    public void instanceFieldValueCanNotBeRead() {
+        loadScript("var Cipher = Java.use('javax.crypto.Cipher');" +
+                "try {" +
+                "  send(Cipher.provider.value);" +
+                "} catch (e) {" +
+                "  send(e.message);" +
+                "}");
+        assertEquals("getter of provider: cannot get an instance field without an instance.", script.getNextMessage());
+    }
+
+  private Script script = null;
 
     private void loadScript(String code) {
         Script script = new Script(TestRunner.fridaJavaBundle +


### PR DESCRIPTION
Fix for Issue #139, Java Wrapper's getClass() should return Wrapper of 'java.lang.Class'.
Fix for Issue #143, Java's fields should be accessible even without an instance.