### PR TITLE
add Runtime and ClassLinker discovery support for Android 10

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -410,8 +410,7 @@ function getArtVMSpec (api) {
   };
 }
 
-function _getArtRuntimeSpec (api) {
-  /*
+/*
    * class Runtime {
    * ...
    * gc::Heap* heap_;                <-- we need to find this
@@ -426,13 +425,14 @@ function _getArtRuntimeSpec (api) {
    * InternTable* intern_table_;      <--/
    * ClassLinker* class_linker_;      <-/
    * SignalCatcher* signal_catcher_;
-   * bool use_tombstoned_traces_;     <-------------------- API level >= 27
-   * std::string stack_trace_file_;
+   * bool use_tombstoned_traces_;     <-------------------- API level 27,28
+   * std::string stack_trace_file_;   <-------------------- API level <= 28
    * JavaVMExt* java_vm_;             <-- so we find this then calculate our way backwards
    * ...
    * }
    */
 
+function _getArtRuntimeSpec (api) {
   const vm = api.vm;
   const runtime = api.artRuntime;
 
@@ -444,31 +444,8 @@ function _getArtRuntimeSpec (api) {
   let spec = null;
 
   for (let offset = startOffset; offset !== endOffset; offset += pointerSize) {
-    const value = runtime.add(offset).readPointer();
-    if (value.equals(vm)) {
-      let classLinkerOffset = offset - STD_STRING_SIZE - (2 * pointerSize);
-      if (apiLevel >= 27) {
-        classLinkerOffset -= pointerSize;
-      }
-      const internTableOffset = classLinkerOffset - pointerSize;
-      const threadListOffset = internTableOffset - pointerSize;
-
-      let heapOffset = threadListOffset - (4 * pointerSize);
-      if (apiLevel >= 23) {
-        heapOffset -= 3 * pointerSize;
-      }
-      if (apiLevel >= 24) {
-        heapOffset -= pointerSize;
-      }
-
-      spec = {
-        offset: {
-          heap: heapOffset,
-          threadList: threadListOffset,
-          internTable: internTableOffset,
-          classLinker: classLinkerOffset
-        }
-      };
+    if (runtime.add(offset).readPointer().equals(vm)) {
+      spec = getSpecByVmOffset(offset, apiLevel);
       break;
     }
   }
@@ -479,6 +456,37 @@ function _getArtRuntimeSpec (api) {
 
   spec.offset.instrumentation = tryDetectInstrumentationOffset();
 
+  return spec;
+}
+
+function getSpecByVmOffset(vm_offset, apiLevel) {
+  let classLinkerOffset = vm_offset - STD_STRING_SIZE - (2 * pointerSize);
+  if (apiLevel >= 27) {
+    classLinkerOffset = vm_offset - STD_STRING_SIZE - (3 * pointerSize);
+  }
+  if (apiLevel >=29) {
+    classLinkerOffset = vm_offset - (2 * pointerSize);
+  }
+
+  const internTableOffset = classLinkerOffset - pointerSize;
+  const threadListOffset = internTableOffset - pointerSize;
+
+  let heapOffset = threadListOffset - (4 * pointerSize);
+  if (apiLevel >= 23) {
+    heapOffset = threadListOffset - (7 * pointerSize);
+  }
+  if (apiLevel >= 24) {
+    heapOffset = threadListOffset - (8 * pointerSize);
+  }
+
+  let spec = {
+    offset: {
+      heap: heapOffset,
+      threadList: threadListOffset,
+      internTable: internTableOffset,
+      classLinker: classLinkerOffset
+    }
+  };
   return spec;
 }
 
@@ -621,7 +629,9 @@ function _getArtClassLinkerSpec (api) {
   for (let offset = startOffset; offset !== endOffset; offset += pointerSize) {
     const value = classLinker.add(offset).readPointer();
     if (value.equals(internTable)) {
-      const delta = (getAndroidApiLevel() >= 23) ? 3 : 5;
+      var delta = 5;
+      if(getAndroidApiLevel() >= 23) delta = 3;
+      if(getAndroidApiLevel() >= 29) delta = 4;
 
       spec = {
         offset: {


### PR DESCRIPTION
Fixes "Error: Unable to determine ClassLinker field offsets" on Android 10.

The offsets at [runtime.h](https://android.googlesource.com/platform/art/+/refs/heads/android10-release/runtime/runtime.h#1000) and [class_linker.h](https://android.googlesource.com/platform/art/+/refs/heads/android10-release/runtime/class_linker.h#1369) in ART runtime changed again.

Some refactoring as well, arguably easier to read the version-dependent adjustments now.

As system apps can't be injected currently (executable-not-read permissions issue, gonna post soon), tested on non-system app.