### PR TITLE
Java.use()/Java.classFactory.use(): add option to bypass caching

### DIFF
--- a/lib/class-factory.js
+++ b/lib/class-factory.js
@@ -140,7 +140,8 @@ function ClassFactory (vm) {
     }
   });
 
-  this.use = function (className, skipCache) {
+  this.use = function (className, options = {}) {
+    const skipCache = options.cache === 'skip';
 
     let C = !skipCache ? getUsedClass(className) : undefined;
     if (C === undefined) {

--- a/lib/class-factory.js
+++ b/lib/class-factory.js
@@ -140,8 +140,9 @@ function ClassFactory (vm) {
     }
   });
 
-  this.use = function (className) {
-    let C = getUsedClass(className);
+  this.use = function (className, skipCache) {
+
+    let C = !skipCache ? getUsedClass(className) : undefined;
     if (C === undefined) {
       const env = vm.getEnv();
       if (loader !== null) {
@@ -167,7 +168,9 @@ function ClassFactory (vm) {
         try {
           C = ensureClass(getClassHandle, className);
         } finally {
-          setUsedClass(className, C);
+          if (!skipCache) {
+            setUsedClass(className, C);
+          }
         }
       } else {
         const canonicalClassName = className.replace(/\./g, '/');
@@ -185,7 +188,9 @@ function ClassFactory (vm) {
         try {
           C = ensureClass(getClassHandle, className);
         } finally {
-          setUsedClass(className, C);
+          if (!skipCache) {
+            setUsedClass(className, C);
+          }
         }
       }
     }


### PR DESCRIPTION
```
This patch introduces the ability to bypass the "usedClass" caching
implementation of the class-factory.js class loader. Prior to this patch, if
two separate java.lang.ClassLoader instances were to load the same class name
string, even if one were to override Java.classFactory.loader prior to each
Java.classFactory.use() call, all calls to use() after the first would result
in the cached (generated) kclass resolver function being used to load the
class, skipping the current loader entirely. For consistency, this patch also
disables calls to setUsedClass() to prevent unexpected side effects. While
it's clearly not performant to be taking the long route each time, there
appears to be no other way to deal with this issue currently as the
"usedClass" mapping is based only on the class name and not also on the
loader.
```

While doing \<REDACTED\>, me and @chaosdata noticed a situation where 
Frida was failing to hook methods of dynamically loaded classes. 
For example, the following code snippet demonstrates this issue:

```java
mBtnLoad.setOnClickListener(new View.OnClickListener() {
    @Override
    public void onClick(View view) {
        final File jarFile =
            new File("/data/local/tmp/test.dex");
        DexClassLoader dexClassLoader =
            new DexClassLoader(jarFile.getAbsolutePath(), getExternalCacheDir().getAbsolutePath(), null, getClassLoader());
        try {
            Class clazz = dexClassLoader.loadClass("com.test.Foo");
            IObject iObject = (IObject) clazz.newInstance();
            System.out.println(iObject.func());
        } catch (ClassNotFoundException e) {
            e.printStackTrace();
        } catch (InstantiationException e) {
            e.printStackTrace();
        } catch (IllegalAccessException e) {
            e.printStackTrace();
        }
    }
});
```

For the above code, we were attempting to override a method on the dynamically loaded class. But because the classloader itself is recreated, the class it loads each time is a different class. So even when overriding `Java.classFactory.loader` with the DexClassLoader instance being used each time, all attempts to use `Java.use()` on the class's name will resolve using the first DexClassLoader instance/Class that were cached. Following that, any attempts to override methods on the Frida wrapper handle value returned by `Java.use()` will result in them being applied only to the first manifested variant of the loaded Java class.
