### PR TITLE
Added option for: Java.use( className, { useLoaderCache: 'enable' })

### DIFF
--- a/lib/class-factory.js
+++ b/lib/class-factory.js
@@ -65,6 +65,7 @@ function ClassFactory (vm) {
   const factory = this;
   let api = null;
   let classes = {};
+  let classes_with_loaders = {}; 
   let patchedClasses = {};
   const patchedMethods = new Set();
   const ignoredThreads = {};
@@ -108,7 +109,18 @@ function ClassFactory (vm) {
     }
 
     classes = {};
+    classes_with_loaders = {};
   };
+
+  Object.defineProperty(this, 'classes_with_loaders', {
+    enumerable: true,
+    get: function () {
+      return classes_with_loaders;
+    },
+    set: function (value) {
+      classes_with_loaders = value;
+    }
+  });
 
   Object.defineProperty(this, 'loader', {
     enumerable: true,
@@ -142,8 +154,14 @@ function ClassFactory (vm) {
 
   this.use = function (className, options = {}) {
     const allowCached = options.cache !== 'skip';
+    const useLoaderCache = options.useLoaderCache === "enable"
+    let C = undefined
+    if (useLoaderCache && (loader !== null)){
+      C = allowCached ? getUsedClassWithLoader(className, loader.hashCode()) : undefined;
+    }else{
+      C = allowCached ? getUsedClass(className) : undefined;
+    }
 
-    let C = allowCached ? getUsedClass(className) : undefined;
     if (C === undefined) {
       const env = vm.getEnv();
       if (loader !== null) {
@@ -171,6 +189,9 @@ function ClassFactory (vm) {
         } finally {
           if (allowCached) {
             setUsedClass(className, C);
+            if (useLoaderCache){ 
+              setUsedClassWithLoader(className, C, loader.hashCode()); 
+            }
           }
         }
       } else {
@@ -210,11 +231,38 @@ function ClassFactory (vm) {
     return kclass;
   }
 
+  function getUsedClassWithLoader(className, classLoaderHash){
+    let kclass;
+    while ((kclass = classes_with_loaders[className] === undefined ? undefined : classes_with_loaders[className][classLoaderHash]) === PENDING_USE) {
+          Thread.sleep(0.05);
+    }
+
+    if (kclass === undefined) {
+        classes_with_loaders[className] = classes_with_loaders[className] === undefined ? {} : classes_with_loaders[className]
+        classes_with_loaders[className][classLoaderHash] = PENDING_USE
+    }
+    return kclass
+  }
+
   function setUsedClass (className, kclass) {
     if (kclass !== undefined) {
       classes[className] = kclass;
     } else {
       delete classes[className];
+    }
+  }
+
+  function setUsedClassWithLoader(className, kclass, classLoaderHash){
+    if (kclass !== undefined) {
+      if (classes_with_loaders[className] === undefined) {
+        classes_with_loaders[className] = { classLoaderHash: kclass }
+      } else {
+        classes_with_loaders[className][classLoaderHash] = kclass
+      }
+    }else{
+      if (classes_with_loaders[className] != undefined) {
+        delete(classes_with_loaders[className][classLoaderHash])
+      } 
     }
   }
 


### PR DESCRIPTION
This patch introduces the ability to use a different class caching strategy with classLoader information. Before this patch, class wrappers are cached in `classes` objects with className as the only identifier. The new caching strategy uses `classes_with_loaders` objects to store used classes with className and classLoader object hash information. This patch also added enum options to Java.use() / Java.classFactory.use(). The new caching strategy can be turned on using `Java.use( className, { useLoaderCache: 'enable' })`

Per our conversation, .hashCode() might not be the best way to approach this; but I decided to keep it as I was not able to find a better solution to retrieve a unique identifier for a given class. Also since this patch is targeting mostly system classLoaders, there might be edge cases but it is unlikely that there are different classLoaders loading same class but with different hash code value. 