### PR TITLE
add getByteArrayRegion

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -469,6 +469,10 @@ Env.prototype.releaseDoubleArrayElements = proxy(198, 'pointer', ['pointer', 'po
   impl(this.handle, array, cArray, JNI_ABORT);
 });
 
+Env.prototype.getByteArrayRegion = proxy(200, 'void', ['pointer', 'pointer', 'int', 'int', 'pointer'], function (impl, array, start, length, cArray) {
+  impl(this.handle, array, start, length, cArray);
+});
+
 Env.prototype.setBooleanArrayRegion = proxy(207, 'void', ['pointer', 'pointer', 'int32', 'int32', 'pointer'], function (impl, array, start, length, cArray) {
   impl(this.handle, array, start, length, cArray);
 });


### PR DESCRIPTION
[related issue](https://github.com/frida/frida/issues/1003)

parameters names change suggestion ? [source](https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html) 

- env: the JNI interface pointer.
- array: a Java array.
- start: the starting index.
- len: the number of elements to be copied.
- buf: the destination buffer.
