### PR TITLE
Fix missing APIs & ClassLinker offset calculation for Android R

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -288,7 +288,12 @@ function _getApi () {
       '_ZN3art31InternalDebuggerControlCallback13StartDebuggerEv',
       '_ZN3art3Dbg15gDebuggerActiveE',
       '_ZN3art15instrumentation15Instrumentation20DeoptimizeEverythingEPKc',
-      '_ZN3art15instrumentation15Instrumentation20DeoptimizeEverythingEv'
+      '_ZN3art15instrumentation15Instrumentation20DeoptimizeEverythingEv',
+      '_ZN3art3Dbg9StartJdwpEv',
+      '_ZN3art3Dbg8GoActiveEv',
+      '_ZN3art3Dbg21RequestDeoptimizationERKNS_21DeoptimizationRequestE',
+      '_ZN3art3Dbg20ManageDeoptimizationEv',
+      '_ZN3art3Dbg9gRegistryE'
     ]
   }] : [{
     module: vmModule.path,
@@ -469,6 +474,7 @@ function _getArtRuntimeSpec (api) {
    * InternTable* intern_table_;      <--/
    * ClassLinker* class_linker_;      <-/
    * SignalCatcher* signal_catcher_;
+   * std::unique_ptr<jni::JniIdManager> jni_id_manager_; <- API level >= 29 and Android Version != 10 (master branch)
    * bool use_tombstoned_traces_;     <-------------------- API level 27/28
    * std::string stack_trace_file_;   <-------------------- API level <= 28
    * JavaVMExt* java_vm_;             <-- so we find this then calculate our way backwards
@@ -483,6 +489,7 @@ function _getArtRuntimeSpec (api) {
   const endOffset = startOffset + (100 * pointerSize);
 
   const apiLevel = getAndroidApiLevel();
+  const androidVersion = getAndroidVersion();
 
   let spec = null;
 
@@ -490,8 +497,10 @@ function _getArtRuntimeSpec (api) {
     const value = runtime.add(offset).readPointer();
     if (value.equals(vm)) {
       let classLinkerOffset;
-      if (apiLevel >= 29) {
+      if (apiLevel == 29 && androidVersion == '10') {
         classLinkerOffset = offset - (2 * pointerSize);
+      } else if (apiLevel >= 29) {
+        classLinkerOffset = offset - (3 * pointerSize);
       } else if (apiLevel >= 27) {
         classLinkerOffset = offset - STD_STRING_SIZE - (3 * pointerSize);
       } else {

--- a/lib/android.js
+++ b/lib/android.js
@@ -497,7 +497,7 @@ function _getArtRuntimeSpec (api) {
     const value = runtime.add(offset).readPointer();
     if (value.equals(vm)) {
       let classLinkerOffset;
-      if (apiLevel == 29 && androidVersion == '10') {
+      if (apiLevel === 29 && androidVersion.split('.')[0] === '10') {
         classLinkerOffset = offset - (2 * pointerSize);
       } else if (apiLevel >= 29) {
         classLinkerOffset = offset - (3 * pointerSize);

--- a/lib/android.js
+++ b/lib/android.js
@@ -489,7 +489,6 @@ function _getArtRuntimeSpec (api) {
   const endOffset = startOffset + (100 * pointerSize);
 
   const apiLevel = getAndroidApiLevel();
-  const androidVersion = getAndroidVersion();
 
   let spec = null;
 

--- a/lib/android.js
+++ b/lib/android.js
@@ -497,7 +497,7 @@ function _getArtRuntimeSpec (api) {
     const value = runtime.add(offset).readPointer();
     if (value.equals(vm)) {
       let classLinkerOffset;
-      if (apiLevel === 29 && androidVersion.split('.')[0] === '10') {
+      if (apiLevel === 29 && getAndroidVersion().split('.')[0] === '10') {
         classLinkerOffset = offset - (2 * pointerSize);
       } else if (apiLevel >= 29) {
         classLinkerOffset = offset - (3 * pointerSize);


### PR DESCRIPTION
This pull request fixes two issues related to the support of Android R (or AOSP's master builds). My setup to reproduce those issues is the following:

- x86 Cuttlefish emulator (https://source.android.com/setup/create/cuttlefish)
- System images of build # 6355543 of AOSP's master branch (https://ci.android.com/builds/branches/aosp-master/grid) for Cuttlefish emulator (aosp_cf_x86_phone)
- Testing script

> Java.perform(() => {
    console.log('Enumerating loaded classes...');
    const classes = Java.enumerateLoadedClassesSync();
    console.log(`Enumerated ${classes.length} classes`);
  });

----------

The first issue is caused by missing APIs as shown in the following error

> Error: Java API only partially available; please file a bug. Missing: _ZN3art3Dbg9StartJdwpEv, _ZN3art3Dbg8GoActiveEv, _ZN3art3Dbg21RequestDeoptimizationERKNS_21DeoptimizationRequestE, _ZN3art3Dbg20ManageDeoptimizationEv, _ZN3art3Dbg9gRegistryE
    at _getApi (../frida-java-bridge/lib/android.js:379)
    at getApi (../frida-java-bridge/lib/android.js:94)
    at _tryInitialize (../frida-java-bridge/index.js:50)
    at Runtime (../frida-java-bridge/index.js:36)
    at ../frida-java-bridge/index.js:501
    at o (node_modules/browser-pack/_prelude.js:1)
    at agent.js:1
    at /repl1.js:9557
    at o (node_modules/browser-pack/_prelude.js:1)

After fixing the first issue, the following error is thrown:

> Error: Unable to determine ClassLinker field offsets
    at _getArtClassLinkerSpec (../frida-java-bridge/lib/android.js:704)
    at ../frida-java-bridge/lib/android.js:2630
    at _getApi (../frida-java-bridge/lib/android.js:413)
    at getApi (../frida-java-bridge/lib/android.js:94)
    at _tryInitialize (../frida-java-bridge/index.js:50)
    at Runtime (../frida-java-bridge/index.js:36)
    at ../frida-java-bridge/index.js:501
    at o (node_modules/browser-pack/_prelude.js:1)
    at agent.js:1

The second error is caused by recent changes to runtime offsets in the runtime.h file (https://android.googlesource.com/platform/art/+/refs/heads/master/runtime/runtime.h#1105). See also related pull request #146.

----------

I'm not sure if it is actually the right time to provide support for Android R+, but this fix helps me in my current objective.