### PR TITLE
Make method interception safer with VMThread

### DIFF
--- a/lib/jvm.js
+++ b/lib/jvm.js
@@ -367,20 +367,14 @@ class JvmMethodMangler {
     }
     this.impl = impl;
     replaceManglers.set(key, this);
-    if (!manglersScheduled) {
-      Script.nextTick(doManglers, vm);
-      manglersScheduled = true;
-    }
+    ensureManglersScheduled(vm);
   }
 
   revert (vm) {
     const { key } = this;
     replaceManglers.delete(key);
     revertManglers.set(key, this);
-    if (!manglersScheduled) {
-      Script.nextTick(doManglers, vm);
-      manglersScheduled = true;
-    }
+    ensureManglersScheduled(vm);
   }
 
   resolveTarget (wrapper, isInstanceMethod, env, api) {
@@ -407,14 +401,26 @@ class JvmMethodMangler {
   }
 }
 
+function ensureManglersScheduled(vm) {
+  if (!manglersScheduled) {
+    manglersScheduled = true;
+    Script.nextTick(doManglers, vm);
+  }
+}
+
 function doManglers (vm) {
+  const localReplaceManglers = new Map(replaceManglers);
+  replaceManglers.clear();
+  const localRevertManglers = new Map(revertManglers);
+  revertManglers.clear();
+  manglersScheduled = false;
   vm.perform(() => {
     const api = getApi();
     const env = vm.getEnv();
     const thread = api['JavaThread::thread_from_jni_environment'](env.handle);
     let force = false;
     withJvmThread(() => {
-      replaceManglers.forEach(mangler => {
+      localReplaceManglers.forEach(mangler => {
         const { method, originalMethod, impl, methodId, newMethod } = mangler;
         if (originalMethod === null) {
           mangler.originalMethod = fetchJvmMethod(method);
@@ -424,7 +430,7 @@ function doManglers (vm) {
           api['Method::set_native_function'](newMethod.method, impl, 0);
         }
       });
-      revertManglers.forEach(mangler => {
+      localRevertManglers.forEach(mangler => {
         const { originalMethod, methodId, newMethod } = mangler;
         if (originalMethod !== null) {
           revertJvmMethod(originalMethod);
@@ -438,9 +444,6 @@ function doManglers (vm) {
     if (force) {
       forceSweep(env.handle);
     }
-    replaceManglers.clear();
-    revertManglers.clear();
-    manglersScheduled = false;
   });
 }
 

--- a/lib/jvm.js
+++ b/lib/jvm.js
@@ -193,6 +193,7 @@ function _getApi () {
 
       '_ZN18VM_RedefineClassesD0Ev',
       '_ZN18VM_RedefineClassesD1Ev',
+      '_ZNK18VM_RedefineClasses14print_on_errorEP12outputStream',
 
       '_ZN6Method10clear_codeEv',
       '_ZN6Method10clear_codeEb',
@@ -481,7 +482,7 @@ function _getJvmThreadSpec () {
   for (let offset = 0; offset !== vtableSize; offset += pointerSize) {
     const element = vtable.add(offset);
     const value = element.readPointer();
-    if (value.equals(redefineClassesOnError) ||
+    if ((redefineClassesOnError !== undefined && value.equals(redefineClassesOnError)) ||
         (redefineClassesDispose0 !== undefined && value.equals(redefineClassesDispose0)) ||
         (redefineClassesDispose1 !== undefined && value.equals(redefineClassesDispose1))) {
       element.writePointer(emptyCallback);

--- a/lib/jvm.js
+++ b/lib/jvm.js
@@ -160,8 +160,11 @@ function _getApi () {
       _ZN19Abstract_VM_Version19jre_release_versionEv: function (address) {
         const getVersion = new NativeFunction(address, 'pointer', [], nativeFunctionOptions);
         const versionS = getVersion().readCString();
-        this.version = (versionS.startsWith('1.8')) ? 8 :
-          (versionS.startsWith('9.')) ? 9 : parseInt(versionS.slice(0, 2), 10);
+        this.version = versionS.startsWith('1.8')
+          ? 8
+          : versionS.startsWith('9.')
+            ? 9
+            : parseInt(versionS.slice(0, 2), 10);
         this.versionS = versionS;
       },
       _ZN14NMethodSweeper11_traversalsE: function (address) {
@@ -357,7 +360,7 @@ class JvmMethodMangler {
 
   replace (impl, isInstanceMethod, argTypes, vm, api) {
     const { key } = this;
-    let mangler = revertManglers.get(key);
+    const mangler = revertManglers.get(key);
     if (mangler !== undefined) {
       revertManglers.delete(key);
       this.method = mangler.method;
@@ -401,7 +404,7 @@ class JvmMethodMangler {
   }
 }
 
-function ensureManglersScheduled(vm) {
+function ensureManglersScheduled (vm) {
   if (!manglersScheduled) {
     manglersScheduled = true;
     Script.nextTick(doManglers, vm);
@@ -455,7 +458,7 @@ function forceSweep (env) {
     'NMethodSweeper::sweep_code_cache': sweep,
     'NMethodSweeper::sweep_in_progress': inProgress,
     'NMethodSweeper::force_sweep': force,
-    'JVM_Sleep': sleep
+    JVM_Sleep: sleep
   } = getApi();
 
   if (force !== undefined) {
@@ -466,23 +469,27 @@ function forceSweep (env) {
   } else {
     let trav = traversals.readS64();
     const endTrav = trav + 2;
+
     while (endTrav > trav) {
-      // force a full sweep if already in progress
+      // Force a full sweep if already in progress.
       fractions.writeS32(1);
       sleep(env, NULL, 50);
-      // check if current nmethod is set
+
+      // Check if current nmethod is set.
       if (!inProgress()) {
-        // force mark_active_nmethods on exit from safepoint
+        // Force mark_active_nmethods on exit from safepoint.
         withJvmThread(() => {
           Thread.sleep(0.05);
         });
       }
-      // don't sweep if already in progress
-      if (shouldSweep.readU8() == 0) {
-        // sanity check to not divide by 0
+
+      const sweepNotAlreadyInProgress = shouldSweep.readU8() === 0;
+      if (sweepNotAlreadyInProgress) {
+        // Sanity check to not divide by 0.
         fractions.writeS32(1);
         sweep();
       }
+
       trav = traversals.readS64();
     }
   }
@@ -525,12 +532,14 @@ function _getJvmThreadSpec () {
     redefineClassesDispose1,
     'VMThread::execute': execute
   } = getApi();
-  const emptyCallback = new NativeCallback(() => {}, 'void', ['pointer']);
+
   const vtablePtr = vtableRedefineClasses.add(2 * pointerSize);
   const vtableSize = 15 * pointerSize;
   const vtable = Memory.dup(vtablePtr, vtableSize);
-  let doItOffset, prologueOffset, epilogueOffset;
 
+  const emptyCallback = new NativeCallback(() => {}, 'void', ['pointer']);
+
+  let doItOffset, prologueOffset, epilogueOffset;
   for (let offset = 0; offset !== vtableSize; offset += pointerSize) {
     const element = vtable.add(offset);
     const value = element.readPointer();
@@ -538,7 +547,7 @@ function _getJvmThreadSpec () {
         (redefineClassesDispose0 !== undefined && value.equals(redefineClassesDispose0)) ||
         (redefineClassesDispose1 !== undefined && value.equals(redefineClassesDispose1))) {
       element.writePointer(emptyCallback);
-    }else if (value.equals(redefineClassesDoIt)) {
+    } else if (value.equals(redefineClassesDoIt)) {
       doItOffset = offset;
     } else if (value.equals(redefineClassesDoItPrologue)) {
       prologueOffset = offset;
@@ -661,18 +670,23 @@ function nativeJvmMethod (method, impl, thread) {
 function fetchJvmMethod (method) {
   const spec = getJvmMethodSpec();
   const constMethod = method.add(spec.method.constMethodOffset).readPointer();
-  const constMehtodSize = constMethod.add(spec.constMethod.sizeOffset).readS32() * pointerSize;
-  const newConstMethod = Memory.alloc(constMehtodSize + spec.method.size);
-  Memory.copy(newConstMethod, constMethod, constMehtodSize);
-  const newMethod = newConstMethod.add(constMehtodSize);
+  const constMethodSize = constMethod.add(spec.constMethod.sizeOffset).readS32() * pointerSize;
+
+  const newConstMethod = Memory.alloc(constMethodSize + spec.method.size);
+  Memory.copy(newConstMethod, constMethod, constMethodSize);
+
+  const newMethod = newConstMethod.add(constMethodSize);
   Memory.copy(newMethod, method, spec.method.size);
-  const result = readJvmMethod(newMethod, newConstMethod, constMehtodSize);
-  const oldMethod = readJvmMethod(method, constMethod, constMehtodSize);
+
+  const result = readJvmMethod(newMethod, newConstMethod, constMethodSize);
+
+  const oldMethod = readJvmMethod(method, constMethod, constMethodSize);
   result.oldMethod = oldMethod;
+
   return result;
 }
 
-function readJvmMethod (method, constMethod, constMehtodSize) {
+function readJvmMethod (method, constMethod, constMethodSize) {
   const api = getApi();
   const spec = getJvmMethodSpec();
 
@@ -705,16 +719,16 @@ function readJvmMethod (method, constMethod, constMehtodSize) {
   const vtableIndex = vtableIndexPtr.readS32();
   const vtable = instanceKlass.add(spec.instanceKlass.vtableOffset);
   const oopMapCache = instanceKlass.add(spec.instanceKlass.oopMapCacheOffset).readPointer();
-  let memberNames = instanceKlass.add(spec.instanceKlass.memberNamesOffset).readPointer();
-  if (api.version < 10) {
-    memberNames = NULL;
-  }
+
+  const memberNames = (api.version >= 10)
+    ? instanceKlass.add(spec.instanceKlass.memberNamesOffset).readPointer()
+    : NULL;
 
   return {
     method: method,
     methodSize: spec.method.size,
     const: constMethod,
-    constSize: constMehtodSize,
+    constSize: constMethodSize,
     constPtr,
     dataPtr,
     countersPtr,
@@ -775,9 +789,10 @@ function _getJvmMethodSpec () {
   const getAdapterPointer = adapterInConstMethod
     ? function (method, constMethod) {
       return constMethod.add(constantPoolOffset + 2 * pointerSize);
-    } : function (method, constMethod) {
+    }
+    : function (method, constMethod) {
       return method.add(i2iEntryOffset + pointerSize);
-  };
+    };
 
   return {
     getAdapterPointer: getAdapterPointer,
@@ -807,20 +822,20 @@ function _getJvmMethodSpec () {
 }
 
 function getJvmKlassSpec (vtableOffset) {
-  const api = getApi()
-  let oopMultiplier = 18;
-  if (9 < api.version && api.version < 12) {
-    oopMultiplier = 17;
-  }
+  const { version: jvmVersion } = getApi();
+
+  const oopMultiplier = (jvmVersion >= 10 && jvmVersion <= 11) ? 17 : 18;
+
   const methodsOffset = vtableOffset - (7 * pointerSize);
   const memberNamesOffset = vtableOffset - (17 * pointerSize);
   const oopMapCacheOffset = vtableOffset - (oopMultiplier * pointerSize);
+
   return {
     vtableOffset,
     methodsOffset,
     memberNamesOffset,
     oopMapCacheOffset
-  }
+  };
 }
 
 function deoptimizeEverything (vm, env) {

--- a/lib/jvm.js
+++ b/lib/jvm.js
@@ -108,6 +108,10 @@ function _getApi () {
       _ZN11OopMapCache22flush_obsolete_entriesEv: ['OopMapCache::flush_obsolete_entries', 'void', ['pointer']],
 
       _ZN14NMethodSweeper11force_sweepEv: ['NMethodSweeper::force_sweep', 'void', []],
+      _ZN14NMethodSweeper16sweep_code_cacheEv: ['NMethodSweeper::sweep_code_cache', 'void', []],
+      _ZN14NMethodSweeper17sweep_in_progressEv: ['NMethodSweeper::sweep_in_progress', 'bool', []],
+
+      JVM_Sleep: ['JVM_Sleep', 'void', ['pointer', 'pointer', 'long']]
     },
     variables: {
       // JDK <= 9
@@ -156,6 +160,15 @@ function _getApi () {
         this.version = (versionS.startsWith('1.8')) ? 8 :
           (versionS.startsWith('9.')) ? 9 : parseInt(versionS.slice(0, 2), 10);
         this.versionS = versionS;
+      },
+      _ZN14NMethodSweeper11_traversalsE: function (address) {
+        this.traversals = address;
+      },
+      _ZN14NMethodSweeper21_sweep_fractions_leftE: function (address) {
+        this.fractions = address;
+      },
+      _ZN14NMethodSweeper13_should_sweepE: function (address) {
+        this.shouldSweep = address;
       }
     },
     optionals: [
@@ -185,7 +198,9 @@ function _getApi () {
       '_ZN6Method10clear_codeEb',
 
       '_ZN20ClassLoaderDataGraph22clean_deallocate_listsEb',
-      '_ZN14NMethodSweeper11force_sweepEv'
+      '_ZN14NMethodSweeper11force_sweepEv',
+      '_ZN14NMethodSweeper21_sweep_fractions_leftE',
+      '_ZN14NMethodSweeper17sweep_in_progressEv'
     ]
   }];
 
@@ -356,13 +371,7 @@ class JvmMethodMangler {
       revert.oldMethod = this.newMethod;
       installJvmMethod(revert, methodId, thread);
     });
-    const force = api['NMethodSweeper::force_sweep'];
-    if (force !== undefined) {
-      Thread.sleep(0.05);
-      api['NMethodSweeper::force_sweep']();
-      Thread.sleep(0.05);
-      api['NMethodSweeper::force_sweep']();
-    }
+    forceSweep(env.handle);
   }
 
   resolveTarget (wrapper, isInstanceMethod, env, api) {
@@ -382,6 +391,47 @@ class JvmMethodMangler {
     this.resolved = jmethodID;
 
     return jmethodID;
+  }
+}
+
+function forceSweep (env) {
+  const {
+    fractions,
+    shouldSweep,
+    traversals,
+    'NMethodSweeper::sweep_code_cache': sweep,
+    'NMethodSweeper::sweep_in_progress': inProgress,
+    'NMethodSweeper::force_sweep': force,
+    'JVM_Sleep': sleep
+  } = getApi();
+
+  if (force !== undefined) {
+    Thread.sleep(0.05);
+    force();
+    Thread.sleep(0.05);
+    force();
+  } else {
+    let trav = traversals.readS64();
+    const endTrav = trav + 2;
+    while (endTrav > trav) {
+      // force a full sweep if already in progress
+      fractions.writeS32(1);
+      sleep(env, NULL, 50);
+      // check if current nmethod is set
+      if (!inProgress()) {
+        // force mark_active_nmethods on exit from safepoint
+        withJvmThread(() => {
+          Thread.sleep(0.05);
+        });
+      }
+      // don't sweep if already in progress
+      if (shouldSweep.readU8() == 0) {
+        // sanity check to not divide by 0
+        fractions.writeS32(1);
+        sweep();
+      }
+      trav = traversals.readS64();
+    }
   }
 }
 

--- a/lib/jvm.js
+++ b/lib/jvm.js
@@ -25,6 +25,9 @@ const getJvmMethodSpec = memoize(_getJvmMethodSpec);
 const getJvmThreadSpec = memoize(_getJvmThreadSpec);
 
 let cachedApi = null;
+let manglersScheduled = false;
+const replaceManglers = new Map();
+const revertManglers = new Map();
 
 function getApi () {
   if (cachedApi === null) {
@@ -348,37 +351,46 @@ class JvmMethodMangler {
     this.originalMethod = null;
     this.newMethod = null;
     this.resolved = null;
+    this.impl = null;
+    this.key = methodId.toString(16);
   }
 
   replace (impl, isInstanceMethod, argTypes, vm, api) {
-    const { method, methodId } = this;
-    const env = vm.getEnv();
-    const thread = api['JavaThread::thread_from_jni_environment'](env.handle);
-    withJvmThread(() => {
-      this.originalMethod = fetchJvmMethod(method);
-      this.newMethod = nativeJvmMethod(method, impl, thread);
-      installJvmMethod(this.newMethod, methodId, thread);
-    });
+    const { key } = this;
+    let mangler = revertManglers.get(key);
+    if (mangler !== undefined) {
+      revertManglers.delete(key);
+      this.method = mangler.method;
+      this.originalMethod = mangler.originalMethod;
+      this.newMethod = mangler.newMethod;
+      this.resolved = mangler.resolved;
+    }
+    this.impl = impl;
+    replaceManglers.set(key, this);
+    if (!manglersScheduled) {
+      Script.nextTick(doManglers, vm);
+      manglersScheduled = true;
+    }
   }
 
   revert (vm) {
-    const { originalMethod, methodId } = this;
-    const env = vm.getEnv();
-    const api = getApi();
-    const thread = api['JavaThread::thread_from_jni_environment'](env.handle);
-    withJvmThread(() => {
-      revertJvmMethod(originalMethod);
-      const revert = originalMethod.oldMethod;
-      revert.oldMethod = this.newMethod;
-      installJvmMethod(revert, methodId, thread);
-    });
-    forceSweep(env.handle);
+    const { key } = this;
+    replaceManglers.delete(key);
+    revertManglers.set(key, this);
+    if (!manglersScheduled) {
+      Script.nextTick(doManglers, vm);
+      manglersScheduled = true;
+    }
   }
 
   resolveTarget (wrapper, isInstanceMethod, env, api) {
-    const { resolved, originalMethod } = this;
+    const { resolved, originalMethod, methodId } = this;
     if (resolved !== null) {
       return resolved;
+    }
+
+    if (originalMethod === null) {
+      return methodId;
     }
 
     const vip = originalMethod.oldMethod.vtableIndexPtr;
@@ -393,6 +405,43 @@ class JvmMethodMangler {
 
     return jmethodID;
   }
+}
+
+function doManglers (vm) {
+  vm.perform(() => {
+    const api = getApi();
+    const env = vm.getEnv();
+    const thread = api['JavaThread::thread_from_jni_environment'](env.handle);
+    let force = false;
+    withJvmThread(() => {
+      replaceManglers.forEach(mangler => {
+        const { method, originalMethod, impl, methodId, newMethod } = mangler;
+        if (originalMethod === null) {
+          mangler.originalMethod = fetchJvmMethod(method);
+          mangler.newMethod = nativeJvmMethod(method, impl, thread);
+          installJvmMethod(mangler.newMethod, methodId, thread);
+        } else {
+          api['Method::set_native_function'](newMethod.method, impl, 0);
+        }
+      });
+      revertManglers.forEach(mangler => {
+        const { originalMethod, methodId, newMethod } = mangler;
+        if (originalMethod !== null) {
+          revertJvmMethod(originalMethod);
+          const revert = originalMethod.oldMethod;
+          revert.oldMethod = newMethod;
+          installJvmMethod(revert, methodId, thread);
+          force = true;
+        }
+      });
+    });
+    if (force) {
+      forceSweep(env.handle);
+    }
+    replaceManglers.clear();
+    revertManglers.clear();
+    manglersScheduled = false;
+  });
 }
 
 function forceSweep (env) {

--- a/lib/jvm.js
+++ b/lib/jvm.js
@@ -5,10 +5,12 @@ const VM = require('./vm');
 const jsizeSize = 4;
 const { pointerSize } = Process;
 
-const JNI_VERSION_1_8 = 0x00010008;
 const JVM_ACC_NATIVE = 0x0100;
 const JVM_ACC_IS_OLD = 0x00010000;
 const JVM_ACC_IS_OBSOLETE = 0x00020000;
+const JVM_ACC_NOT_C2_COMPILABLE = 0x02000000;
+const JVM_ACC_NOT_C1_COMPILABLE = 0x04000000;
+const JVM_ACC_NOT_C2_OSR_COMPILABLE = 0x08000000;
 const JVMTI_VERSION_1_0 = 0x30010000;
 
 const jvmtiCapabilities = {
@@ -20,6 +22,7 @@ const nativeFunctionOptions = {
 };
 
 const getJvmMethodSpec = memoize(_getJvmMethodSpec);
+const getJvmThreadSpec = memoize(_getJvmThreadSpec);
 
 let cachedApi = null;
 
@@ -53,6 +56,19 @@ function _getApi () {
       _ZN6Method21clear_native_functionEv: ['Method::clear_native_function', 'void', ['pointer']],
       _ZN6Method24restore_unshareable_infoEP6Thread: ['Method::restore_unshareable_info', 'void', ['pointer', 'pointer']],
       _ZN6Method10jmethod_idEv: ['Method::jmethod_id', 'pointer', ['pointer']],
+      _ZN6Method10clear_codeEv: function (address) {
+        const clearCode = new NativeFunction(address, 'void', ['pointer'], nativeFunctionOptions);
+        this['Method::clear_code'] = function (thisPtr) {
+          clearCode(thisPtr);
+        };
+      },
+      _ZN6Method10clear_codeEb: function (address) {
+        const clearCode = new NativeFunction(address, 'void', ['pointer', 'int'], nativeFunctionOptions);
+        const lock = 0;
+        this['Method::clear_code'] = function (thisPtr) {
+          clearCode(thisPtr, lock);
+        };
+      },
 
       _ZNK5Klass15start_of_vtableEv: ['Klass::start_of_vtable', 'pointer', ['pointer']],
       _ZNK13InstanceKlass6vtableEv: ['InstanceKlass::vtable', 'pointer', ['pointer']],
@@ -83,8 +99,15 @@ function _getApi () {
       },
 
       _ZN20ClassLoaderDataGraph10classes_doEP12KlassClosure: ['ClassLoaderDataGraph::classes_do', 'void', ['pointer']],
+      _ZN20ClassLoaderDataGraph22clean_deallocate_listsEb: ['ClassLoaderDataGraph::clean_deallocate_lists', 'void', ['int']],
 
-      _ZN10JavaThread27thread_from_jni_environmentEP7JNIEnv_: ['JavaThread::thread_from_jni_environment', 'pointer', ['pointer']]
+      _ZN10JavaThread27thread_from_jni_environmentEP7JNIEnv_: ['JavaThread::thread_from_jni_environment', 'pointer', ['pointer']],
+
+      _ZN8VMThread7executeEP12VM_Operation: ['VMThread::execute', 'void', ['pointer']],
+
+      _ZN11OopMapCache22flush_obsolete_entriesEv: ['OopMapCache::flush_obsolete_entries', 'void', ['pointer']],
+
+      _ZN14NMethodSweeper11force_sweepEv: ['NMethodSweeper::force_sweep', 'void', []],
     },
     variables: {
       // JDK <= 9
@@ -102,6 +125,37 @@ function _getApi () {
       // JDK >= 13
       _ZN18VM_RedefineClasses22AdjustAndCleanMetadata8do_klassEP5Klass: function (address) {
         this.doKlass = address;
+      },
+      _ZTV18VM_RedefineClasses: function (address) {
+        this.vtableRedefineClasses = address;
+      },
+      _ZN18VM_RedefineClasses4doitEv: function (address) {
+        this.redefineClassesDoIt = address;
+      },
+      _ZN18VM_RedefineClasses13doit_prologueEv: function (address) {
+        this.redefineClassesDoItPrologue = address;
+      },
+      _ZN18VM_RedefineClasses13doit_epilogueEv: function (address) {
+        this.redefineClassesDoItEpilogue = address;
+      },
+      _ZN18VM_RedefineClassesD0Ev: function (address) {
+        this.redefineClassesDispose0 = address;
+      },
+      _ZN18VM_RedefineClassesD1Ev: function (address) {
+        this.redefineClassesDispose1 = address;
+      },
+      _ZNK18VM_RedefineClasses26allow_nested_vm_operationsEv: function (address) {
+        this.redefineClassesAllow = address;
+      },
+      _ZNK18VM_RedefineClasses14print_on_errorEP12outputStream: function (address) {
+        this.redefineClassesOnError = address;
+      },
+      _ZN19Abstract_VM_Version19jre_release_versionEv: function (address) {
+        const getVersion = new NativeFunction(address, 'pointer', [], nativeFunctionOptions);
+        const versionS = getVersion().readCString();
+        this.version = (versionS.startsWith('1.8')) ? 8 :
+          (versionS.startsWith('9.')) ? 9 : parseInt(versionS.slice(0, 2), 10);
+        this.versionS = versionS;
       }
     },
     optionals: [
@@ -122,7 +176,13 @@ function _getApi () {
       '_ZN18VM_RedefineClasses14_the_class_oopE',
       '_ZN18VM_RedefineClasses10_the_classE',
       '_ZN18VM_RedefineClasses25AdjustCpoolCacheAndVtable8do_klassEP5Klass',
-      '_ZN18VM_RedefineClasses22AdjustAndCleanMetadata8do_klassEP5Klass'
+      '_ZN18VM_RedefineClasses22AdjustAndCleanMetadata8do_klassEP5Klass',
+
+      '_ZN18VM_RedefineClassesD0Ev',
+      '_ZN18VM_RedefineClassesD1Ev',
+
+      '_ZN6Method10clear_codeEv',
+      '_ZN6Method10clear_codeEb'
     ]
   }];
 
@@ -194,7 +254,6 @@ function _getApi () {
   temporaryApi.$delete = new NativeFunction(Module.getExportByName(null, '_ZdlPv'), 'void', ['pointer'], nativeFunctionOptions);
 
   temporaryApi.jvmti = getEnvJvmti(temporaryApi);
-
   return temporaryApi;
 }
 
@@ -274,17 +333,30 @@ class JvmMethodMangler {
 
   replace (impl, isInstanceMethod, argTypes, vm, api) {
     const { method, methodId } = this;
-    this.originalMethod = fetchJvmMethod(method, vm);
-    this.newMethod = nativeJvmMethod(method, impl, vm);
-    installJvmMethod(this.newMethod, methodId, vm);
+    const env = vm.getEnv();
+    const thread = api['JavaThread::thread_from_jni_environment'](env.handle);
+    withJvmThread(() => {
+      this.originalMethod = fetchJvmMethod(method);
+      this.newMethod = nativeJvmMethod(method, impl, thread);
+      installJvmMethod(this.newMethod, methodId, thread);
+    });
   }
 
   revert (vm) {
     const { originalMethod, methodId } = this;
-    revertJvmMethod(originalMethod);
-    const revert = originalMethod.oldMethod;
-    revert.oldMethod = this.newMethod;
-    installJvmMethod(revert, methodId, vm);
+    const env = vm.getEnv();
+    const api = getApi();
+    const thread = api['JavaThread::thread_from_jni_environment'](env.handle);
+    withJvmThread(() => {
+      revertJvmMethod(originalMethod);
+      const revert = originalMethod.oldMethod;
+      revert.oldMethod = this.newMethod;
+      installJvmMethod(revert, methodId, thread);
+    });
+    Thread.sleep(0.05);
+    api['NMethodSweeper::force_sweep']();
+    Thread.sleep(0.05);
+    api['NMethodSweeper::force_sweep']();
   }
 
   resolveTarget (wrapper, isInstanceMethod, env, api) {
@@ -307,15 +379,85 @@ class JvmMethodMangler {
   }
 }
 
+function withJvmThread (fn, fnPrologue, fnEpilogue) {
+  const {
+    execute,
+    vtable,
+    vtableSize,
+    doItOffset,
+    prologueOffset,
+    epilogueOffset
+  } = getJvmThreadSpec();
+  const vtableDup = Memory.dup(vtable, vtableSize);
+  const vmOperation = Memory.alloc(pointerSize * 25);
+  vmOperation.writePointer(vtableDup);
+  const doIt = new NativeCallback(fn, 'void', ['pointer']);
+  vtableDup.add(doItOffset).writePointer(doIt);
+  if (fnPrologue !== undefined) {
+    const prologue = new NativeCallback(fnPrologue, 'int', ['pointer']);
+    vtableDup.add(prologueOffset).writePointer(prologue);
+  }
+  if (fnEpilogue !== undefined) {
+    const epilogue = new NativeCallback(fnEpilogue, 'void', ['pointer']);
+    vtableDup.add(epilogueOffset).writePointer(epilogue);
+  }
+  execute(vmOperation);
+}
+
+function _getJvmThreadSpec () {
+  const {
+    vtableRedefineClasses,
+    redefineClassesDoIt,
+    redefineClassesDoItPrologue,
+    redefineClassesDoItEpilogue,
+    redefineClassesOnError,
+    redefineClassesAllow,
+    redefineClassesDispose0,
+    redefineClassesDispose1,
+    'VMThread::execute': execute
+  } = getApi();
+  const emptyCallback = new NativeCallback(() => {}, 'void', ['pointer']);
+  const vtablePtr = vtableRedefineClasses.add(2 * pointerSize);
+  const vtableSize = 15 * pointerSize;
+  const vtable = Memory.dup(vtablePtr, vtableSize);
+  let doItOffset, prologueOffset, epilogueOffset;
+
+  for (let offset = 0; offset !== vtableSize; offset += pointerSize) {
+    const element = vtable.add(offset);
+    const value = element.readPointer();
+    if (value.equals(redefineClassesOnError) ||
+        (redefineClassesDispose0 !== undefined && value.equals(redefineClassesDispose0)) ||
+        (redefineClassesDispose1 !== undefined && value.equals(redefineClassesDispose1))) {
+      element.writePointer(emptyCallback);
+    }else if (value.equals(redefineClassesDoIt)) {
+      doItOffset = offset;
+    } else if (value.equals(redefineClassesDoItPrologue)) {
+      prologueOffset = offset;
+      element.writePointer(redefineClassesAllow);
+    } else if (value.equals(redefineClassesDoItEpilogue)) {
+      epilogueOffset = offset;
+      element.writePointer(emptyCallback);
+    }
+  }
+
+  return {
+    execute,
+    emptyCallback,
+    vtable,
+    vtableSize,
+    doItOffset,
+    prologueOffset,
+    epilogueOffset
+  };
+}
+
 function makeMethodMangler (methodId) {
   return new JvmMethodMangler(methodId);
 }
 
-function installJvmMethod (method, methodId, vm) {
+function installJvmMethod (method, methodId, thread) {
   const { method: handle, oldMethod: old } = method;
   const api = getApi();
-  const env = vm.getEnv();
-  const thread = api['JavaThread::thread_from_jni_environment'](env.handle);
 
   // Replace position in methodsArray with new method.
   method.methodsArray.add(method.methodIndex * pointerSize).writePointer(handle);
@@ -331,6 +473,14 @@ function installJvmMethod (method, methodId, vm) {
   old.accessFlagsPtr.writeU32((old.accessFlags | JVM_ACC_IS_OLD | JVM_ACC_IS_OBSOLETE) >>> 0);
 
   // Deoptimize dependent code.
+  const flushObs = api['OopMapCache::flush_obsolete_entries'];
+  if (flushObs !== undefined) {
+    const { oopMapCache } = method;
+    if (!oopMapCache.isNull()) {
+      flushObs(oopMapCache);
+    }
+  }
+
   const mark = api['VM_RedefineClasses::mark_dependent_code'];
   const flush = api['VM_RedefineClasses::flush_dependent_code'];
   if (mark !== undefined) {
@@ -367,50 +517,56 @@ function installJvmMethod (method, methodId, vm) {
       }
     }
   }
+  api['ClassLoaderDataGraph::clean_deallocate_lists'](0);
 }
 
-function nativeJvmMethod (method, impl, vm) {
+function nativeJvmMethod (method, impl, thread) {
   const api = getApi();
 
-  const newMethod = fetchJvmMethod(method, vm);
+  const newMethod = fetchJvmMethod(method);
   newMethod.constPtr.writePointer(newMethod.const);
-  newMethod.accessFlagsPtr.writeU32((newMethod.accessFlags | JVM_ACC_NATIVE) >>> 0);
+  const flags = (newMethod.accessFlags | JVM_ACC_NATIVE |
+    JVM_ACC_NOT_C2_COMPILABLE | JVM_ACC_NOT_C1_COMPILABLE |
+    JVM_ACC_NOT_C2_OSR_COMPILABLE) >>> 0;
+  newMethod.accessFlagsPtr.writeU32(flags);
   newMethod.signatureHandler.writePointer(NULL);
   newMethod.adapter.writePointer(NULL);
   newMethod.i2iEntry.writePointer(NULL);
+  api['Method::clear_code'](newMethod.method);
 
-  // clear_native_function will also clear _from_compiled_entry
-  // and _from_interpreted_entry
+  newMethod.dataPtr.writePointer(NULL);
+  newMethod.countersPtr.writePointer(NULL);
+  newMethod.stackmapPtr.writePointer(NULL);
+
   api['Method::clear_native_function'](newMethod.method);
   api['Method::set_native_function'](newMethod.method, impl, 0);
 
-  // Link method (Method::link_method)
-  const env = vm.getEnv();
-  const thread = api['JavaThread::thread_from_jni_environment'](env.handle);
   api['Method::restore_unshareable_info'](newMethod.method, thread);
 
   return newMethod;
 }
 
-function fetchJvmMethod (method, vm) {
-  const spec = getJvmMethodSpec(vm);
+function fetchJvmMethod (method) {
+  const spec = getJvmMethodSpec();
   const constMethod = method.add(spec.method.constMethodOffset).readPointer();
   const constMehtodSize = constMethod.add(spec.constMethod.sizeOffset).readS32() * pointerSize;
   const newConstMethod = Memory.alloc(constMehtodSize + spec.method.size);
   Memory.copy(newConstMethod, constMethod, constMehtodSize);
   const newMethod = newConstMethod.add(constMehtodSize);
   Memory.copy(newMethod, method, spec.method.size);
-  const result = readJvmMethod(newMethod, newConstMethod, constMehtodSize, vm);
-  const oldMethod = readJvmMethod(method, constMethod, constMehtodSize, vm);
+  const result = readJvmMethod(newMethod, newConstMethod, constMehtodSize);
+  const oldMethod = readJvmMethod(method, constMethod, constMehtodSize);
   result.oldMethod = oldMethod;
   return result;
 }
 
-function readJvmMethod (method, constMethod, constMehtodSize, vm) {
+function readJvmMethod (method, constMethod, constMehtodSize) {
   const api = getApi();
-  const spec = getJvmMethodSpec(vm);
+  const spec = getJvmMethodSpec();
 
   const constPtr = method.add(spec.method.constMethodOffset);
+  const dataPtr = method.add(spec.method.methodDataOffset);
+  const countersPtr = method.add(spec.method.methodCountersOffset);
   const accessFlagsPtr = method.add(spec.method.accessFlagsOffset);
   const accessFlags = accessFlagsPtr.readU32();
   const adapter = spec.getAdapterPointer(method, constMethod);
@@ -418,15 +574,15 @@ function readJvmMethod (method, constMethod, constMehtodSize, vm) {
   const signatureHandler = method.add(spec.method.signatureHandlerOffset);
 
   const constantPool = constMethod.add(spec.constMethod.constantPoolOffset).readPointer();
+  const stackmapPtr = constMethod.add(spec.constMethod.stackmapDataOffset);
   const instanceKlass = constantPool.add(spec.constantPool.instanceKlassOffset).readPointer();
   const cache = constantPool.add(spec.constantPool.cacheOffset).readPointer();
 
-  if (spec.instanceKlass.vtableOffset === 0) {
+  if (spec.instanceKlass === undefined) {
     const klassVtable = api['InstanceKlass::vtable'](instanceKlass);
     const vtableOffset = klassVtable.add(pointerSize).readS32();
-    spec.instanceKlass.vtableOffset = vtableOffset;
-    spec.instanceKlass.methodsOffset = vtableOffset - (7 * pointerSize);
-    spec.instanceKlass.memberNamesOffset = vtableOffset - (17 * pointerSize);
+    const klassSpec = getJvmKlassSpec(vtableOffset);
+    spec.instanceKlass = klassSpec;
   }
 
   const methods = instanceKlass.add(spec.instanceKlass.methodsOffset).readPointer();
@@ -436,7 +592,11 @@ function readJvmMethod (method, constMethod, constMehtodSize, vm) {
   const vtableIndexPtr = method.add(spec.method.vtableIndexOffset);
   const vtableIndex = vtableIndexPtr.readS32();
   const vtable = instanceKlass.add(spec.instanceKlass.vtableOffset);
-  const memberNames = instanceKlass.add(spec.instanceKlass.memberNamesOffset).readPointer();
+  const oopMapCache = instanceKlass.add(spec.instanceKlass.oopMapCacheOffset).readPointer();
+  let memberNames = instanceKlass.add(spec.instanceKlass.memberNamesOffset).readPointer();
+  if (api.version < 10) {
+    memberNames = NULL;
+  }
 
   return {
     method: method,
@@ -444,6 +604,9 @@ function readJvmMethod (method, constMethod, constMehtodSize, vm) {
     const: constMethod,
     constSize: constMehtodSize,
     constPtr,
+    dataPtr,
+    countersPtr,
+    stackmapPtr,
     instanceKlass,
     methodsArray,
     methodsCount,
@@ -457,83 +620,95 @@ function readJvmMethod (method, constMethod, constMehtodSize, vm) {
     i2iEntry,
     signatureHandler,
     memberNames,
-    cache
+    cache,
+    oopMapCache
   };
 }
 
 function revertJvmMethod (method) {
-  Memory.copy(method.oldMethod.const, method.const, method.constSize);
-  Memory.copy(method.oldMethod.method, method.method, method.methodSize);
+  const { oldMethod: old } = method;
+  old.accessFlagsPtr.writeU32(old.accessFlags);
+  old.vtableIndexPtr.writeS32(old.vtableIndex);
 }
 
-function _getJvmMethodSpec (vm) {
+function _getJvmMethodSpec () {
   const api = getApi();
 
-  let spec;
-  vm.perform(() => {
-    const env = vm.getEnv();
-    const version = env.getVersion();
-    const adapterInConstMethod = (version > JNI_VERSION_1_8) ? 1 : 0;
+  const adapterInConstMethod = (api.version > 8) ? 1 : 0;
 
-    const isNative = 1;
-    const methodSize = api['Method::size'](isNative) * pointerSize;
-    const constMethodOffset = pointerSize;
-    const accessFlagsOffset = 4 * pointerSize;
-    const vtableIndexOffset = accessFlagsOffset + 4;
-    const i2iEntryOffset = vtableIndexOffset + 4 + pointerSize;
-    const nativeFunctionOffset = methodSize - 2 * pointerSize;
-    const signatureHandlerOffset = methodSize - pointerSize;
+  const isNative = 1;
+  const methodSize = api['Method::size'](isNative) * pointerSize;
+  const constMethodOffset = pointerSize;
+  const methodDataOffset = 2 * pointerSize;
+  const methodCountersOffset = 3 * pointerSize;
+  const accessFlagsOffset = 4 * pointerSize;
+  const vtableIndexOffset = accessFlagsOffset + 4;
+  const i2iEntryOffset = vtableIndexOffset + 4 + pointerSize;
+  const nativeFunctionOffset = methodSize - 2 * pointerSize;
+  const signatureHandlerOffset = methodSize - pointerSize;
 
-    const constantPoolOffset = pointerSize;
-    const constMethodSizeOffset = (3 + adapterInConstMethod) * pointerSize;
-    const methodIdnumOffset = constMethodSizeOffset + 0xe;
+  const constantPoolOffset = pointerSize;
+  const stackmapDataOffset = 2 * pointerSize;
+  const constMethodSizeOffset = (3 + adapterInConstMethod) * pointerSize;
+  const methodIdnumOffset = constMethodSizeOffset + 0xe;
 
-    const cacheOffset = 2 * pointerSize;
-    const instanceKlassOffset = 3 * pointerSize;
-    let vtableOffset = 0;
-    let methodsOffset = 0;
-    let memberNamesOffset = 0;
-    if ('Klass::start_of_vtable' in api) {
-      vtableOffset = api['Klass::start_of_vtable'](NULL).toInt32();
-      methodsOffset = vtableOffset - (7 * pointerSize);
-      memberNamesOffset = vtableOffset - (17 * pointerSize);
-    }
+  const cacheOffset = 2 * pointerSize;
+  const instanceKlassOffset = 3 * pointerSize;
+  let klassSpec;
+  if ('Klass::start_of_vtable' in api) {
+    const vtableOffset = api['Klass::start_of_vtable'](NULL).toInt32();
+    klassSpec = getJvmKlassSpec(vtableOffset);
+  }
 
-    const getAdapterPointer = adapterInConstMethod
-      ? function (method, constMethod) {
-        return constMethod.add(constantPoolOffset + 2 * pointerSize);
-      } : function (method, constMethod) {
-        return method.add(i2iEntryOffset + pointerSize);
-      };
+  const getAdapterPointer = adapterInConstMethod
+    ? function (method, constMethod) {
+      return constMethod.add(constantPoolOffset + 2 * pointerSize);
+    } : function (method, constMethod) {
+      return method.add(i2iEntryOffset + pointerSize);
+  };
 
-    spec = {
-      getAdapterPointer: getAdapterPointer,
-      method: {
-        size: methodSize,
-        constMethodOffset,
-        accessFlagsOffset,
-        vtableIndexOffset,
-        i2iEntryOffset,
-        nativeFunctionOffset,
-        signatureHandlerOffset
-      },
-      constMethod: {
-        constantPoolOffset,
-        sizeOffset: constMethodSizeOffset,
-        methodIdnumOffset
-      },
-      constantPool: {
-        cacheOffset,
-        instanceKlassOffset
-      },
-      instanceKlass: {
-        vtableOffset,
-        methodsOffset,
-        memberNamesOffset
-      }
-    };
-  });
-  return spec;
+  return {
+    getAdapterPointer: getAdapterPointer,
+    method: {
+      size: methodSize,
+      constMethodOffset,
+      methodDataOffset,
+      methodCountersOffset,
+      accessFlagsOffset,
+      vtableIndexOffset,
+      i2iEntryOffset,
+      nativeFunctionOffset,
+      signatureHandlerOffset
+    },
+    constMethod: {
+      constantPoolOffset,
+      stackmapDataOffset,
+      sizeOffset: constMethodSizeOffset,
+      methodIdnumOffset
+    },
+    constantPool: {
+      cacheOffset,
+      instanceKlassOffset
+    },
+    instanceKlass: klassSpec
+  };
+}
+
+function getJvmKlassSpec (vtableOffset) {
+  const api = getApi()
+  let oopMultiplier = 18;
+  if (9 < api.version && api.version < 12) {
+    oopMultiplier = 17;
+  }
+  const methodsOffset = vtableOffset - (7 * pointerSize);
+  const memberNamesOffset = vtableOffset - (17 * pointerSize);
+  const oopMapCacheOffset = vtableOffset - (oopMultiplier * pointerSize);
+  return {
+    vtableOffset,
+    methodsOffset,
+    memberNamesOffset,
+    oopMapCacheOffset
+  }
 }
 
 function deoptimizeEverything (vm, env) {

--- a/lib/jvm.js
+++ b/lib/jvm.js
@@ -413,15 +413,19 @@ function ensureManglersScheduled (vm) {
 
 function doManglers (vm) {
   const localReplaceManglers = new Map(replaceManglers);
-  replaceManglers.clear();
   const localRevertManglers = new Map(revertManglers);
+  replaceManglers.clear();
   revertManglers.clear();
   manglersScheduled = false;
+
   vm.perform(() => {
     const api = getApi();
     const env = vm.getEnv();
+
     const thread = api['JavaThread::thread_from_jni_environment'](env.handle);
+
     let force = false;
+
     withJvmThread(() => {
       localReplaceManglers.forEach(mangler => {
         const { method, originalMethod, impl, methodId, newMethod } = mangler;
@@ -433,6 +437,7 @@ function doManglers (vm) {
           api['Method::set_native_function'](newMethod.method, impl, 0);
         }
       });
+
       localRevertManglers.forEach(mangler => {
         const { originalMethod, methodId, newMethod } = mangler;
         if (originalMethod !== null) {
@@ -444,6 +449,7 @@ function doManglers (vm) {
         }
       });
     });
+
     if (force) {
       forceSweep(env.handle);
     }
@@ -504,19 +510,25 @@ function withJvmThread (fn, fnPrologue, fnEpilogue) {
     prologueOffset,
     epilogueOffset
   } = getJvmThreadSpec();
+
   const vtableDup = Memory.dup(vtable, vtableSize);
+
   const vmOperation = Memory.alloc(pointerSize * 25);
   vmOperation.writePointer(vtableDup);
+
   const doIt = new NativeCallback(fn, 'void', ['pointer']);
   vtableDup.add(doItOffset).writePointer(doIt);
+
   if (fnPrologue !== undefined) {
     const prologue = new NativeCallback(fnPrologue, 'int', ['pointer']);
     vtableDup.add(prologueOffset).writePointer(prologue);
   }
+
   if (fnEpilogue !== undefined) {
     const epilogue = new NativeCallback(fnEpilogue, 'void', ['pointer']);
     vtableDup.add(epilogueOffset).writePointer(epilogue);
   }
+
   execute(vmOperation);
 }
 

--- a/lib/jvm.js
+++ b/lib/jvm.js
@@ -182,7 +182,10 @@ function _getApi () {
       '_ZN18VM_RedefineClassesD1Ev',
 
       '_ZN6Method10clear_codeEv',
-      '_ZN6Method10clear_codeEb'
+      '_ZN6Method10clear_codeEb',
+
+      '_ZN20ClassLoaderDataGraph22clean_deallocate_listsEb',
+      '_ZN14NMethodSweeper11force_sweepEv'
     ]
   }];
 
@@ -353,10 +356,13 @@ class JvmMethodMangler {
       revert.oldMethod = this.newMethod;
       installJvmMethod(revert, methodId, thread);
     });
-    Thread.sleep(0.05);
-    api['NMethodSweeper::force_sweep']();
-    Thread.sleep(0.05);
-    api['NMethodSweeper::force_sweep']();
+    const force = api['NMethodSweeper::force_sweep'];
+    if (force !== undefined) {
+      Thread.sleep(0.05);
+      api['NMethodSweeper::force_sweep']();
+      Thread.sleep(0.05);
+      api['NMethodSweeper::force_sweep']();
+    }
   }
 
   resolveTarget (wrapper, isInstanceMethod, env, api) {
@@ -517,7 +523,10 @@ function installJvmMethod (method, methodId, thread) {
       }
     }
   }
-  api['ClassLoaderDataGraph::clean_deallocate_lists'](0);
+  const clean = api['ClassLoaderDataGraph::clean_deallocate_lists'];
+  if (clean !== undefined) {
+    clean(0);
+  }
 }
 
 function nativeJvmMethod (method, impl, thread) {


### PR DESCRIPTION
Install new methods using VMThread::execute which blocks all Java
threads and makes it safer to do interception of hot methods.

However, compiled methods that are on the stack will still not be
flushed when calling the deoptimization logic. This is a problem
when reverting back to the old method and flushing the new method
which has been allocated using Frida’s Memory module. In this instance
we force the flushing of old compiled methods using the
NMethodSweeper::force_sweep API. We have to do it twice because of
some logic in nmethod::can_convert_to_zombie.