### PR TITLE
fixes #179 by removing kAccFastInterpreterToInterpreterInvoke from or…

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -17,6 +17,7 @@ const kAccFinal = 0x0010;
 const kAccNative = 0x0100;
 const kAccFastNative = 0x00080000;
 const kAccCriticalNative = 0x00200000;
+const kAccFastInterpreterToInterpreterInvoke = 0x40000000;
 const kAccPublicApi = 0x10000000;
 const kAccXposedHookedMethod = 0x10000000;
 
@@ -1411,7 +1412,9 @@ class ArtMethodMangler {
 
     // kAccFastNative so that the VM doesn't get suspended while executing JNI
     // (so that we can modify the ArtMethod on the fly)
-    const replacementFlags = ((originalFlags & ~kAccCriticalNative) | kAccNative | kAccFastNative) >>> 0;
+    // remove kAccFastInterpreterToInterpreterInvoke to disable use_fast_path in interpreter_common.h
+    const replacementFlags = ((originalFlags & ~(kAccCriticalNative|kAccFastInterpreterToInterpreterInvoke)) | kAccNative | kAccFastNative) >>> 0;
+
 
     patchArtMethod(hookedMethod, {
       jniCode: impl,

--- a/lib/android.js
+++ b/lib/android.js
@@ -1412,7 +1412,7 @@ class ArtMethodMangler {
 
     // kAccFastNative so that the VM doesn't get suspended while executing JNI
     // (so that we can modify the ArtMethod on the fly)
-    // remove kAccFastInterpreterToInterpreterInvoke to disable use_fast_path in interpreter_common.h
+    // Remove kAccFastInterpreterToInterpreterInvoke to disable use_fast_path in interpreter_common.h
     const replacementFlags = ((originalFlags & ~(kAccCriticalNative|kAccFastInterpreterToInterpreterInvoke)) | kAccNative | kAccFastNative) >>> 0;
 
 

--- a/lib/android.js
+++ b/lib/android.js
@@ -1413,7 +1413,8 @@ class ArtMethodMangler {
     // kAccFastNative so that the VM doesn't get suspended while executing JNI
     // (so that we can modify the ArtMethod on the fly)
     // Remove kAccFastInterpreterToInterpreterInvoke to disable use_fast_path in interpreter_common.h
-    const replacementFlags = ((originalFlags & ~(kAccCriticalNative|kAccFastInterpreterToInterpreterInvoke)) | kAccNative | kAccFastNative) >>> 0;
+    const replacementFlags = ((originalFlags & ~(kAccCriticalNative | kAccFastInterpreterToInterpreterInvoke)) |
+        kAccNative | kAccFastNative) >>> 0;
 
 
     patchArtMethod(hookedMethod, {

--- a/lib/android.js
+++ b/lib/android.js
@@ -1416,7 +1416,6 @@ class ArtMethodMangler {
     const replacementFlags = ((originalFlags & ~(kAccCriticalNative | kAccFastInterpreterToInterpreterInvoke)) |
         kAccNative | kAccFastNative) >>> 0;
 
-
     patchArtMethod(hookedMethod, {
       jniCode: impl,
       accessFlags: replacementFlags,


### PR DESCRIPTION
Fixes #179 thus Java methods can be hooked after those have been added to fast_path. 