### PR TITLE
Properly support Android R

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -21,6 +21,8 @@ const kAccFastInterpreterToInterpreterInvoke = 0x40000000;
 const kAccPublicApi = 0x10000000;
 const kAccXposedHookedMethod = 0x10000000;
 
+const kPointer = 0x0;
+
 const ENV_VTABLE_OFFSET_EXCEPTION_CLEAR = 17 * pointerSize;
 const ENV_VTABLE_OFFSET_FATAL_ERROR = 18 * pointerSize;
 
@@ -254,7 +256,9 @@ function _getApi () {
         this['art::Instrumentation::DeoptimizeEverything'] = function (instrumentation, key) {
           deoptimize(instrumentation);
         };
-      }
+      },
+
+      _ZN3art3jni12JniIdManager14DecodeMethodIdEP10_jmethodID: ['art::jni::JniIdManager::DecodeMethodId', 'pointer', ['pointer', 'pointer']]
     },
     variables: {
       _ZN3art3Dbg9gRegistryE: function (address) {
@@ -301,7 +305,8 @@ function _getApi () {
       '_ZN3art3Dbg8GoActiveEv',
       '_ZN3art3Dbg21RequestDeoptimizationERKNS_21DeoptimizationRequestE',
       '_ZN3art3Dbg20ManageDeoptimizationEv',
-      '_ZN3art3Dbg9gRegistryE'
+      '_ZN3art3Dbg9gRegistryE',
+      '_ZN3art3jni12JniIdManager14DecodeMethodIdEP10_jmethodID'
     ]
   }] : [{
     module: vmModule.path,
@@ -503,9 +508,11 @@ function _getArtRuntimeSpec (api) {
   for (let offset = startOffset; offset !== endOffset; offset += pointerSize) {
     const value = runtime.add(offset).readPointer();
     if (value.equals(vm)) {
-      let classLinkerOffset;
+      let classLinkerOffset = null;
+      let jniIdManagerOffset = null;
       if (apiLevel >= 30 || getAndroidCodename() === 'R') {
         classLinkerOffset = offset - (3 * pointerSize);
+        jniIdManagerOffset = offset - pointerSize;
       } else if (apiLevel >= 29) {
         classLinkerOffset = offset - (2 * pointerSize);
       } else if (apiLevel >= 27) {
@@ -531,7 +538,8 @@ function _getArtRuntimeSpec (api) {
           heap: heapOffset,
           threadList: threadListOffset,
           internTable: internTableOffset,
-          classLinker: classLinkerOffset
+          classLinker: classLinkerOffset,
+          jniIdManager: jniIdManagerOffset
         }
       };
       break;
@@ -543,6 +551,7 @@ function _getArtRuntimeSpec (api) {
   }
 
   spec.offset.instrumentation = tryDetectInstrumentationOffset();
+  spec.offset.jniIdsIndirection = tryDetectJniIdsIndirectionOffset();
 
   return spec;
 }
@@ -600,6 +609,59 @@ function parseArmInstrumentationOffset (insn) {
 
 function parseArm64InstrumentationOffset (insn) {
   if (insn.mnemonic === 'ldrb') {
+    return insn.operands[1].value.disp;
+  }
+
+  return null;
+}
+
+const jniIdsIndirectionOffsetParsers = {
+  ia32: parsex86JniIdsIndirectionOffset,
+  x64: parsex86JniIdsIndirectionOffset,
+  arm: parseArmJniIdsIndirectionOffset,
+  arm64: parseArm64JniIdsIndirectionOffset
+};
+
+function tryDetectJniIdsIndirectionOffset () {
+  let cur = Module.findExportByName('libart.so', '_ZN3art7Runtime12SetJniIdTypeENS_9JniIdTypeE');
+  if (cur === null) {
+    return null;
+  }
+
+  const tryParse = jniIdsIndirectionOffsetParsers[Process.arch];
+
+  for (let i = 0; i !== 20; i++) {
+    const insn = Instruction.parse(cur);
+
+    const offset = tryParse(insn);
+    if (offset !== null) {
+      return offset;
+    }
+
+    cur = insn.next;
+  }
+
+  throw new Error('Unable to determine Runtime.jni_ids_indirection_ offset');
+}
+
+function parsex86JniIdsIndirectionOffset (insn) {
+  if (insn.mnemonic === 'cmp') {
+    return insn.operands[0].value.disp;
+  }
+
+  return null;
+}
+
+function parseArmJniIdsIndirectionOffset (insn) {
+  if (insn.mnemonic === 'ldr.w') {
+    return insn.operands[1].value.disp;
+  }
+
+  return null;
+}
+
+function parseArm64JniIdsIndirectionOffset (insn) {
+  if (insn.mnemonic === 'ldr' && insn.next.mnemonic === 'cmp') {
     return insn.operands[1].value.disp;
   }
 
@@ -752,7 +814,7 @@ function _getArtMethodSpec (vm) {
   vm.perform(() => {
     const env = vm.getEnv();
     const process = env.findClass('android/os/Process');
-    const setArgV0 = env.getStaticMethodId(process, 'setArgV0', '(Ljava/lang/String;)V');
+    const setArgV0 = unwrapMethodId(env.getStaticMethodId(process, 'setArgV0', '(Ljava/lang/String;)V'));
     env.deleteLocalRef(process);
 
     const runtimeModule = Process.getModuleByName('libandroid_runtime.so');
@@ -1388,8 +1450,31 @@ function revertGlobalPatches () {
   patchedClasses.clear();
 }
 
+function unwrapMethodId (methodId) {
+  const api = getApi();
+
+  const runtimeOffset = getArtRuntimeSpec(api).offset;
+  const jniIdManagerOffset = runtimeOffset.jniIdManager;
+  const jniIdsIndirectionOffset = runtimeOffset.jniIdsIndirection;
+
+  if (jniIdManagerOffset !== null && jniIdsIndirectionOffset !== null) {
+    const runtime = api.artRuntime;
+
+    const jniIdsIndirection = runtime.add(jniIdsIndirectionOffset).readInt();
+
+    if (jniIdsIndirection !== kPointer) {
+      const jniIdManager = runtime.add(jniIdManagerOffset).readPointer();
+      return api['art::jni::JniIdManager::DecodeMethodId'](jniIdManager, methodId);
+    }
+  }
+
+  return methodId;
+}
+
 class ArtMethodMangler {
-  constructor (methodId) {
+  constructor (opaqueMethodId) {
+    const methodId = unwrapMethodId(opaqueMethodId);
+
     this.methodId = methodId;
     this.originalMethod = null;
     this.hookedMethod = methodId;


### PR DESCRIPTION
Android R introduced opaque JNI ids for methods and fields. See the commit: https://android.googlesource.com/platform/art/+/21d5994583c679cd5d8573b5d35dbd659bdca2c7.

The indirection mode will affect method hooks when enabled for the ART runtime since the 'methodId' returned from JNI function calls will be
set to a manged id instead of the "real" one that points to the 'ArtMethod'.

This mode will typically be enabled if the application has the 'debuggable' attribute set to true. See also https://android.googlesource.com/platform/art/+/refs/heads/master/runtime/runtime.cc#1075