### PR TITLE
Fix ART internals probing on Android 11/arm64

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -630,15 +630,17 @@ function tryDetectJniIdsIndirectionOffset () {
 
   const tryParse = jniIdsIndirectionOffsetParsers[Process.arch];
 
+  let prevInsn = null;
   for (let i = 0; i !== 20; i++) {
     const insn = Instruction.parse(cur);
 
-    const offset = tryParse(insn);
+    const offset = tryParse(insn, prevInsn);
     if (offset !== null) {
       return offset;
     }
 
     cur = insn.next;
+    prevInsn = insn;
   }
 
   throw new Error('Unable to determine Runtime.jni_ids_indirection_ offset');
@@ -660,9 +662,9 @@ function parseArmJniIdsIndirectionOffset (insn) {
   return null;
 }
 
-function parseArm64JniIdsIndirectionOffset (insn) {
-  if (insn.mnemonic === 'ldr' && insn.next.mnemonic === 'cmp') {
-    return insn.operands[1].value.disp;
+function parseArm64JniIdsIndirectionOffset (insn, prevInsn) {
+  if (insn.mnemonic === 'cmp' && prevInsn?.mnemonic === 'ldr') {
+    return prevInsn.operands[1].value.disp;
   }
 
   return null;


### PR DESCRIPTION
Fix Android 11 error:

```sh
frida-ps -aiU
Failed to enumerate applications: unable to determine Runtime.jni_ids_indirection_ offset
```