### PR TITLE
Repair deoptimizeEverything() function for Android 11

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -586,27 +586,52 @@ function tryDetectInstrumentationOffset () {
 }
 
 function parsex86InstrumentationOffset (insn) {
-  if (insn.mnemonic === 'mov' && insn.operands[1].type === 'imm') {
-    return insn.operands[1].value;
+  if (insn.mnemonic !== 'mov') {
+    return null;
   }
 
-  return null;
+  const op1 = insn.operands[1];
+  if (op1.type !== 'imm') {
+    return null;
+  }
+
+  return op1.value;
 }
 
 function parseArmInstrumentationOffset (insn) {
-  if (insn.mnemonic === 'add.w' && insn.operands.length == 3 && insn.operands[2].type === 'imm') {
-    return insn.operands[2].value;
+  if (insn.mnemonic !== 'add.w') {
+    return null;
   }
 
-  return null;
+  const ops = insn.operands;
+  if (ops.length !== 3) {
+    return null;
+  }
+
+  const op2 = ops[2];
+  if (op2.type !== 'imm') {
+    return null;
+  }
+
+  return op2.value;
 }
 
 function parseArm64InstrumentationOffset (insn) {
-  if (insn.mnemonic === 'add' && insn.operands.length == 3 && insn.operands[2].type === 'imm') {
-    return insn.operands[2].value;
+  if (insn.mnemonic !== 'add') {
+    return null;
   }
 
-  return null;
+  const ops = insn.operands;
+  if (ops.length !== 3) {
+    return null;
+  }
+
+  const op2 = ops[2];
+  if (op2.type !== 'imm') {
+    return null;
+  }
+
+  return op2.value;
 }
 
 const jniIdsIndirectionOffsetParsers = {
@@ -685,7 +710,7 @@ function _getArtInstrumentationSpec () {
     '8-27': 352,
     '8-28': 392,
     '8-29': 328,
-    '8-30': 336,
+    '8-30': 336
   };
 
   const deoptEnabledOffset = deoptimizationEnabledOffsets[`${Process.pointerSize}-${getAndroidApiLevel()}`];
@@ -1727,16 +1752,16 @@ function deoptimizeEverything (vm, env) {
         const session = startJdwp(api);
         jdwpSessions.push(session);
       }
-  
+
       if (!api.isDebuggerActive()) {
         api['art::Dbg::GoActive']();
       }
-  
+
       const kFullDeoptimization = 3;
       const request = Memory.alloc(8 + pointerSize);
       request.writeU32(kFullDeoptimization);
       api['art::Dbg::RequestDeoptimization'](request);
-  
+
       api['art::Dbg::ManageDeoptimization']();
     } else {
       const instrumentation = api.artInstrumentation;

--- a/lib/android.js
+++ b/lib/android.js
@@ -564,7 +564,7 @@ const instrumentationOffsetParsers = {
 };
 
 function tryDetectInstrumentationOffset () {
-  let cur = Module.findExportByName('libart.so', '_ZN3art3Dbg22RequiresDeoptimizationEv');
+  let cur = Module.findExportByName('libart.so', 'MterpHandleException');
   if (cur === null) {
     return null;
   }
@@ -576,7 +576,7 @@ function tryDetectInstrumentationOffset () {
 
     const offset = tryParse(insn);
     if (offset !== null) {
-      return offset - getArtInstrumentationSpec().offset.forcedInterpretOnly;
+      return offset;
     }
 
     cur = insn.next;
@@ -586,30 +586,24 @@ function tryDetectInstrumentationOffset () {
 }
 
 function parsex86InstrumentationOffset (insn) {
-  const { mnemonic } = insn;
-
-  if (insn.mnemonic === 'cmp') {
-    return insn.operands[0].value.disp;
-  }
-
-  if (mnemonic === 'movzx') {
-    return insn.operands[1].value.disp;
+  if (insn.mnemonic === 'mov' && insn.operands[1].type === 'imm') {
+    return insn.operands[1].value;
   }
 
   return null;
 }
 
 function parseArmInstrumentationOffset (insn) {
-  if (insn.mnemonic === 'ldrb.w') {
-    return insn.operands[1].value.disp;
+  if (insn.mnemonic === 'add.w' && insn.operands.length == 3 && insn.operands[2].type === 'imm') {
+    return insn.operands[2].value;
   }
 
   return null;
 }
 
 function parseArm64InstrumentationOffset (insn) {
-  if (insn.mnemonic === 'ldrb') {
-    return insn.operands[1].value.disp;
+  if (insn.mnemonic === 'add' && insn.operands.length == 3 && insn.operands[2].type === 'imm') {
+    return insn.operands[2].value;
   }
 
   return null;
@@ -681,6 +675,7 @@ function _getArtInstrumentationSpec () {
     '4-27': 196,
     '4-28': 212,
     '4-29': 172,
+    '4-30': 180,
     '8-21': 224,
     '8-22': 224,
     '8-23': 296,
@@ -689,7 +684,8 @@ function _getArtInstrumentationSpec () {
     '8-26': 352,
     '8-27': 352,
     '8-28': 392,
-    '8-29': 328
+    '8-29': 328,
+    '8-30': 336,
   };
 
   const deoptEnabledOffset = deoptimizationEnabledOffsets[`${Process.pointerSize}-${getAndroidApiLevel()}`];
@@ -1726,21 +1722,35 @@ function deoptimizeEverything (vm, env) {
   }
 
   withRunnableArtThread(vm, env, thread => {
-    if (!api.isJdwpStarted()) {
-      const session = startJdwp(api);
-      jdwpSessions.push(session);
+    if (getAndroidApiLevel() < 30) {
+      if (!api.isJdwpStarted()) {
+        const session = startJdwp(api);
+        jdwpSessions.push(session);
+      }
+  
+      if (!api.isDebuggerActive()) {
+        api['art::Dbg::GoActive']();
+      }
+  
+      const kFullDeoptimization = 3;
+      const request = Memory.alloc(8 + pointerSize);
+      request.writeU32(kFullDeoptimization);
+      api['art::Dbg::RequestDeoptimization'](request);
+  
+      api['art::Dbg::ManageDeoptimization']();
+    } else {
+      const instrumentation = api.artInstrumentation;
+      if (instrumentation === null) {
+        throw new Error('Unable to find Instrumentation class in ART, please file a bug to frida-java-bridge');
+      }
+
+      const deoptimizationEnabled = !!instrumentation.add(getArtInstrumentationSpec().offset.deoptimizationEnabled).readU8();
+      if (!deoptimizationEnabled) {
+        api['art::Instrumentation::EnableDeoptimization'](instrumentation);
+      }
+
+      api['art::Instrumentation::DeoptimizeEverything'](instrumentation, Memory.allocUtf8String('frida'));
     }
-
-    if (!api.isDebuggerActive()) {
-      api['art::Dbg::GoActive']();
-    }
-
-    const kFullDeoptimization = 3;
-    const request = Memory.alloc(8 + pointerSize);
-    request.writeU32(kFullDeoptimization);
-    api['art::Dbg::RequestDeoptimization'](request);
-
-    api['art::Dbg::ManageDeoptimization']();
   });
 }
 


### PR DESCRIPTION
Since Android 11, Google removed the internal JDWP implementation from ART due to the risk of bit-rot ([reference](https://android.googlesource.com/platform/art/+/fc58809f7b932d86234130be15487017dc37b0cf)). This change causes the crashes discussed in PR #159 , and breaks the deoptimizeEverything function.

After investigating the related changes carefully, I think the only solution I can suggest is "drop the JDWP deoptimization solution for Android 11 and above, and rollback to the old hacky solution based on ART internal `Instrumentation` implementations." So, yep, ¯\_(ツ)_/¯

I've tested these codes on a Pixel 3a device with latest Android 11 release, but feel free to do more tests cause there may be some other edge cases I've never know before.