### PR TITLE
Improve the logic about detecting instrumentation offset.

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -586,12 +586,15 @@ function tryDetectInstrumentationOffset () {
 }
 
 function parsex86InstrumentationOffset (insn) {
-  if (insn.mnemonic !== 'mov') {
+  if (insn.mnemonic !== 'mov' && insn.mnemonic !== 'add') {
     return null;
   }
 
   const op1 = insn.operands[1];
   if (op1.type !== 'imm') {
+    return null;
+  }
+  if (op1.value < 0x100 || op1.value > 0x400) {
     return null;
   }
 

--- a/lib/android.js
+++ b/lib/android.js
@@ -582,9 +582,6 @@ function tryDetectInstrumentationOffset () {
     cur = insn.next;
   }
 
-  if (getAndroidApiLevel() >= 30) {
-    throw new Error('Unable to determine Runtime.instrumentation_ offset');
-  }
   return null;
 }
 
@@ -1773,6 +1770,9 @@ function deoptimizeEverything (vm, env) {
       const instrumentation = api.artInstrumentation;
       if (instrumentation === null) {
         throw new Error('Unable to find Instrumentation class in ART; please file a bug');
+      }
+      if (instrumentation === undefined) {
+        throw new Error('ART Instrumentation class didn\'t got initialized; please file a bug');
       }
 
       const deoptimizationEnabled = !!instrumentation.add(getArtInstrumentationSpec().offset.deoptimizationEnabled).readU8();

--- a/lib/android.js
+++ b/lib/android.js
@@ -582,6 +582,9 @@ function tryDetectInstrumentationOffset () {
     cur = insn.next;
   }
 
+  if (getAndroidApiLevel() >= 30) {
+    throw new Error('Unable to determine Runtime.instrumentation_ offset');
+  }
   return null;
 }
 

--- a/lib/android.js
+++ b/lib/android.js
@@ -586,7 +586,8 @@ function tryDetectInstrumentationOffset () {
 }
 
 function parsex86InstrumentationOffset (insn) {
-  if (insn.mnemonic !== 'mov' && insn.mnemonic !== 'add') {
+  const { mnemonic } = insn;
+  if (mnemonic !== 'mov' && mnemonic !== 'add') {
     return null;
   }
 


### PR DESCRIPTION
Hi @oleavr , I've briefly checked the issue #186 , and figured out a more robust way to parse the offset for x86/x86_64 platforms. This could be helpful for future Android releases, and allow us to use `Instrumentation` on old devices in case of need.

BTW, I also added the throw back for API level >= 30, cause I thought this may be helpful for our debugging.