### PR TITLE
add Java.deoptimizeBootImage which calls art::Runtime::DeoptimizeBootImage

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ const {
   withRunnableArtThread,
   makeArtClassVisitor,
   makeArtClassLoaderVisitor,
-  deoptimizeEverything
+  deoptimizeEverything,
+  deoptimizeBootImage
 } = require('./lib/android');
 const ClassFactory = require('./lib/class-factory');
 const ClassModel = require('./lib/class-model');
@@ -492,6 +493,11 @@ class Runtime {
   deoptimizeEverything () {
     const { vm } = this;
     return deoptimizeEverything(vm, vm.getEnv());
+  }
+
+  deoptimizeBootImage () {
+    const { vm } = this;
+    return deoptimizeBootImage(vm, vm.getEnv());
   }
 
   _checkAvailable () {

--- a/lib/android.js
+++ b/lib/android.js
@@ -302,6 +302,7 @@ function _getApi () {
       '_ZN3art3Dbg15gDebuggerActiveE',
       '_ZN3art15instrumentation15Instrumentation20DeoptimizeEverythingEPKc',
       '_ZN3art15instrumentation15Instrumentation20DeoptimizeEverythingEv',
+      '_ZN3art7Runtime19DeoptimizeBootImageEv',
       '_ZN3art3Dbg9StartJdwpEv',
       '_ZN3art3Dbg8GoActiveEv',
       '_ZN3art3Dbg21RequestDeoptimizationERKNS_21DeoptimizationRequestE',

--- a/lib/android.js
+++ b/lib/android.js
@@ -257,6 +257,7 @@ function _getApi () {
           deoptimize(instrumentation);
         };
       },
+      _ZN3art7Runtime19DeoptimizeBootImageEv: ['art::Runtime::DeoptimizeBootImage', 'void', ['pointer']],
 
       _ZN3art3jni12JniIdManager14DecodeMethodIdEP10_jmethodID: ['art::jni::JniIdManager::DecodeMethodId', 'pointer', ['pointer', 'pointer']]
     },
@@ -1783,6 +1784,14 @@ function deoptimizeEverything (vm, env) {
   });
 }
 
+function deoptimizeBootImage (vm, env) {
+  const api = getApi();
+
+  withRunnableArtThread(vm, env, thread => {
+    api['art::Runtime::DeoptimizeBootImage'](api.artRuntime);
+  });
+}
+
 class JdwpSession {
   constructor () {
     /*
@@ -3193,6 +3202,7 @@ module.exports = {
   makeMethodMangler,
   revertGlobalPatches,
   deoptimizeEverything,
+  deoptimizeBootImage,
   HandleVector,
   VariableSizedHandleScope,
   makeObjectVisitorPredicate,


### PR DESCRIPTION
Adds the method `Java.deoptimizeBootImage` which is similar to deoptimizeEverything but only ensures the deoptimization of code in the boot image oat files. This method works by simply calling `art::Runtime::DeoptimizeBootImage` which uses a class visitor to set the quickCode pointer to the interpreter bridge for every class in the boot image. This is a serious performance gain in some situations where the app code itself is slow when deoptimized and it is not necessary to do in order for hooks to be hit reliably. 