### PR TITLE
Few fixes for ART

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,16 @@ all:
 	@echo "Nothing to build. To run the test-suite: make check"
 
 check: node_modules
+	@echo ""
+	@echo "[*] Running the test suite with optimizations disabled (interpreter mode)."
+	@echo ""
+	@$(MAKE) check-run
+	@echo ""
+	@echo "[*] Running the test suite with optimizations enabled."
+	@echo ""
+	@$(MAKE) RUNNER_ARGS="--enable-optimizations" check-run
+
+check-run: node_modules
 	$(MAKE) -C test deploy
 	$(MAKE) -C test run
 

--- a/lib/android.js
+++ b/lib/android.js
@@ -1479,15 +1479,15 @@ function instrumentArtQuickEntrypoints (vm) {
 function instrumentArtMethodInvocationFromInterpreter () {
   const apiLevel = getAndroidApiLevel();
 
-  let interpreterDoCallSymbolRegex;
+  let artInterpreterDoCallSymbolRegex;
   if (apiLevel <= 22) {
-    interpreterDoCallSymbolRegex = /^_ZN3art11interpreter6DoCallILb[0-1]ELb[0-1]EEEbPNS_6mirror9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtPNS_6JValueE$/;
+    artInterpreterDoCallSymbolRegex = /^_ZN3art11interpreter6DoCallILb[0-1]ELb[0-1]EEEbPNS_6mirror9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtPNS_6JValueE$/;
   } else {
-    interpreterDoCallSymbolRegex = /^_ZN3art11interpreter6DoCallILb[0-1]ELb[0-1]EEEbPNS_9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtPNS_6JValueE$/;
+    artInterpreterDoCallSymbolRegex = /^_ZN3art11interpreter6DoCallILb[0-1]ELb[0-1]EEEbPNS_9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtPNS_6JValueE$/;
   }
 
   Module.enumerateExports('libart.so')
-    .filter(exp => interpreterDoCallSymbolRegex.test(exp.name))
+    .filter(exp => artInterpreterDoCallSymbolRegex.test(exp.name))
     .forEach(exp => {
       Interceptor.attach(exp.address, function (args) {
         const method = args[0];
@@ -2117,7 +2117,7 @@ class ArtQuickCodeInterceptor {
     if (prologueLength === 0) {
       this._destroyTrampoline();
 
-      throw new Error('Unable to intercept quick code of ArtMethod.');
+      throw new Error('Unable to intercept quick code of ArtMethod');
     }
 
     this.overwrittenPrologueLength = prologueLength;

--- a/lib/android.js
+++ b/lib/android.js
@@ -1477,8 +1477,17 @@ function instrumentArtQuickEntrypoints (vm) {
 }
 
 function instrumentArtMethodInvocationFromInterpreter () {
+  const apiLevel = getAndroidApiLevel();
+
+  let interpreterDoCallSymbolRegex;
+  if (apiLevel <= 22) {
+    interpreterDoCallSymbolRegex = /^_ZN3art11interpreter6DoCallILb[0-1]ELb[0-1]EEEbPNS_6mirror9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtPNS_6JValueE$/;
+  } else {
+    interpreterDoCallSymbolRegex = /^_ZN3art11interpreter6DoCallILb[0-1]ELb[0-1]EEEbPNS_9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtPNS_6JValueE$/;
+  }
+
   Module.enumerateExports('libart.so')
-    .filter(exp => /^_ZN3art11interpreter6DoCallILb[0-1]ELb[0-1]EEEbPNS_9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtPNS_6JValueE$/.test(exp.name))
+    .filter(exp => interpreterDoCallSymbolRegex.test(exp.name))
     .forEach(exp => {
       Interceptor.attach(exp.address, function (args) {
         const method = args[0];
@@ -1772,7 +1781,12 @@ function writeArtQuickCodeReplacementTrampolineIA32 (trampoline, target, vm) {
 
     do {
       offset = relocator.readOne();
-    } while (offset < ART_QUICK_CODE_HOOK_REDIRECT_SIZE_IA32);
+    } while (offset < ART_QUICK_CODE_HOOK_REDIRECT_SIZE_IA32 && !relocator.eoi);
+
+    if (offset < ART_QUICK_CODE_HOOK_REDIRECT_SIZE_IA32) {
+      offset = 0;
+      return;
+    }
 
     relocator.writeAll();
 
@@ -1835,7 +1849,12 @@ function writeArtQuickCodeReplacementTrampolineX64 (trampoline, target, vm) {
 
     do {
       offset = relocator.readOne();
-    } while (offset < ART_QUICK_CODE_HOOK_REDIRECT_SIZE_X64);
+    } while (offset < ART_QUICK_CODE_HOOK_REDIRECT_SIZE_X64 && !relocator.eoi);
+
+    if (offset < ART_QUICK_CODE_HOOK_REDIRECT_SIZE_X64) {
+      offset = 0;
+      return;
+    }
 
     relocator.writeAll();
 
@@ -1922,7 +1941,12 @@ function writeArtQuickCodeReplacementTrampolineArm (trampoline, target, vm) {
 
     do {
       offset = relocator.readOne();
-    } while (offset < ART_QUICK_CODE_HOOK_REDIRECT_SIZE_ARM);
+    } while (offset < ART_QUICK_CODE_HOOK_REDIRECT_SIZE_ARM && !relocator.eoi);
+
+    if (offset < ART_QUICK_CODE_HOOK_REDIRECT_SIZE_ARM) {
+      offset = 0;
+      return;
+    }
 
     relocator.writeAll();
 
@@ -2004,7 +2028,12 @@ function writeArtQuickCodeReplacementTrampolineArm64 (trampoline, target, vm) {
 
     do {
       offset = relocator.readOne();
-    } while (offset < ART_QUICK_CODE_HOOK_REDIRECT_SIZE_ARM64);
+    } while (offset < ART_QUICK_CODE_HOOK_REDIRECT_SIZE_ARM64 && !relocator.eoi);
+
+    if (offset < ART_QUICK_CODE_HOOK_REDIRECT_SIZE_ARM64) {
+      offset = 0;
+      return;
+    }
 
     relocator.writeAll();
 
@@ -2076,11 +2105,21 @@ class ArtQuickCodeInterceptor {
     this.trampoline = trampolineAllocator.allocateSlice();
   }
 
+  _destroyTrampoline () {
+    trampolineAllocator.freeSlice(this.trampoline);
+  }
+
   activate (vm) {
     this._createTrampoline();
 
     const writeTrampoline = artQuickCodeReplacementTrampolineWriters[Process.arch];
     const prologueLength = writeTrampoline(this.trampoline, this.quickCode, vm);
+    if (prologueLength === 0) {
+      this._destroyTrampoline();
+
+      throw new Error('Unable to intercept quick code of ArtMethod.');
+    }
+
     this.overwrittenPrologueLength = prologueLength;
 
     const quickCodeAddress = (Process.arch === 'arm')
@@ -2108,7 +2147,7 @@ class ArtQuickCodeInterceptor {
       writer.flush();
     });
 
-    trampolineAllocator.freeSlice(this.trampoline);
+    this._destroyTrampoline();
   }
 }
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -27,23 +27,19 @@ deploy: build/$(ANDROID_ABI)/runner build/tests.dex build/frida-java-bridge.js
 	adb push $^ build/$(ANDROID_ABI)/libartpalette.so $(deploy_data_dir)
 
 run:
-	@echo
-	@echo "[*] Running test suite with optimizations enabled."
-	@adb shell "LD_LIBRARY_PATH='$(APEX_LIBDIRS):$(deploy_data_dir)' $(deploy_data_dir)/runner --enable-optimizations"
-	@echo "[*] Running test suite with optimizations disabled (interpreter mode)."
-	@adb shell "LD_LIBRARY_PATH='$(APEX_LIBDIRS):$(deploy_data_dir)' $(deploy_data_dir)/runner"
+	adb shell "LD_LIBRARY_PATH='$(APEX_LIBDIRS):$(deploy_data_dir)' $(deploy_data_dir)/runner $(RUNNER_ARGS)"
 
 watch:
 	npm run watch &
 	./node_modules/.bin/chokidar \
 		build/frida-java-bridge.js \
 		-c "adb push build/frida-java-bridge.js $(deploy_data_dir) \
-			&& adb shell 'LD_LIBRARY_PATH='$(APEX_LIBDIRS):$(deploy_data_dir)' $(deploy_data_dir)/runner'"
+			&& adb shell 'LD_LIBRARY_PATH='$(APEX_LIBDIRS):$(deploy_data_dir)' $(deploy_data_dir)/runner $(RUNNER_ARGS)'"
 
 debug: build/gdb.setup
 	adb shell "rm -f $(deploy_data_dir)/debug-socket"
 	adb push $(ANDROID_NDK_ROOT)/prebuilt/android-$(ANDROID_ARCH)/gdbserver/gdbserver $(deploy_data_dir)
-	adb shell "$(deploy_data_dir)/gdbserver +$(deploy_data_dir)/debug-socket $(deploy_data_dir)/runner" &
+	adb shell "$(deploy_data_dir)/gdbserver +$(deploy_data_dir)/debug-socket $(deploy_data_dir)/runner $(RUNNER_ARGS)" &
 	sleep 1
 	adb forward tcp:$(DEBUG_PORT) localfilesystem:$(deploy_data_dir)/debug-socket
 	$(ANDROID_NDK_ROOT)/prebuilt/$(build_os_arch)/bin/gdb -x build/gdb.setup

--- a/test/Makefile
+++ b/test/Makefile
@@ -27,7 +27,11 @@ deploy: build/$(ANDROID_ABI)/runner build/tests.dex build/frida-java-bridge.js
 	adb push $^ build/$(ANDROID_ABI)/libartpalette.so $(deploy_data_dir)
 
 run:
-	adb shell "LD_LIBRARY_PATH='$(APEX_LIBDIRS):$(deploy_data_dir)' $(deploy_data_dir)/runner"
+	@echo
+	@echo "[*] Running test suite with optimizations enabled."
+	@adb shell "LD_LIBRARY_PATH='$(APEX_LIBDIRS):$(deploy_data_dir)' $(deploy_data_dir)/runner --enable-optimizations"
+	@echo "[*] Running test suite with optimizations disabled (interpreter mode)."
+	@adb shell "LD_LIBRARY_PATH='$(APEX_LIBDIRS):$(deploy_data_dir)' $(deploy_data_dir)/runner"
 
 watch:
 	npm run watch &

--- a/test/re/frida/MethodTest.java
+++ b/test/re/frida/MethodTest.java
@@ -8,9 +8,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.io.IOException;
 import java.lang.UnsupportedOperationException;
 import javax.crypto.Cipher;
-import java.io.IOException;
 
 public class MethodTest {
     @Rule

--- a/test/re/frida/MethodTest.java
+++ b/test/re/frida/MethodTest.java
@@ -507,6 +507,18 @@ public class MethodTest {
         assertEquals("yes", script.getNextMessage());
     }
 
+    @Test
+    public void nativeMethodCanBeReplaced() {
+        loadScript("var Badger = Java.use('re.frida.Badger');" +
+                "Badger.nativeMethod.implementation = function (str) {" +
+                    "send(str);" +
+                "};");
+
+        Badger badger = new Badger();
+        badger.nativeMethod("randomString");
+        assertEquals("randomString", script.getNextMessage());
+    }
+
     private Script script = null;
 
     private void loadScript(String code) {
@@ -589,6 +601,8 @@ class Badger {
     public Badger() {
         id = nextId++;
     }
+
+    public native void nativeMethod(String arg);
 
     public void die() {
         throw new IllegalStateException("Already dead");

--- a/test/re/frida/MethodTest.java
+++ b/test/re/frida/MethodTest.java
@@ -8,6 +8,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.lang.UnsupportedOperationException;
 import javax.crypto.Cipher;
 import java.io.IOException;
 
@@ -602,13 +603,15 @@ class Badger {
     }
 
     public int returnZero() {
-        return 0;
+        return new Integer(0).intValue();
     }
 
     public void eat(Mushroom mushroom) {
+        throw new UnsupportedOperationException("NOT IMPLEMENTED");
     }
 
     public void eatMany(Mushroom[] mushrooms) {
+        throw new UnsupportedOperationException("NOT IMPLEMENTED");
     }
 
     public String observe(String[] labels) {
@@ -625,6 +628,7 @@ class Badger {
     }
 
     public void eatString(String label) {
+        throw new UnsupportedOperationException("NOT IMPLEMENTED");
     }
 
     public void feedString() {
@@ -635,6 +639,7 @@ class Badger {
     }
 
     public void eatBytes(byte[] bytes) {
+        throw new UnsupportedOperationException("NOT IMPLEMENTED");
     }
 
     public Mushroom makeMushroom() {

--- a/test/runner.c
+++ b/test/runner.c
@@ -34,11 +34,13 @@ struct _DestroyScriptOperation
 static void frida_java_init_vm (JavaVM ** vm, JNIEnv ** env, gboolean optimization_enabled);
 static void frida_java_register_test_runner_api (JNIEnv * env);
 static void frida_java_register_script_api (JNIEnv * env);
+static void frida_java_register_badger_api (JNIEnv * env);
 static JNIEnv * frida_java_get_env (void);
 
 static void re_frida_test_runner_register_class_loader (JNIEnv * env, jclass klass, jobject loader);
 
 static jlong re_frida_script_create (JNIEnv * env, jobject self, jstring source_code);
+static void re_frida_badger_native_method (JNIEnv * env, jobject self, jstring str);
 static gboolean create_script_on_js_thread (gpointer user_data);
 static void on_create_ready (GObject * source_object, GAsyncResult * result, gpointer user_data);
 static void on_load_ready (GObject * source_object, GAsyncResult * result, gpointer user_data);
@@ -60,6 +62,11 @@ static const JNINativeMethod re_frida_script_methods[] =
 {
   { "create", "(Ljava/lang/String;)J", re_frida_script_create },
   { "destroy", "(J)V", re_frida_script_destroy },
+};
+
+static const JNINativeMethod re_frida_badger_methods[] =
+{
+  { "nativeMethod", "(Ljava/lang/String;)V", re_frida_badger_native_method },
 };
 
 static JavaVM * java_vm;
@@ -107,6 +114,7 @@ main (int argc, char * argv[])
 
   frida_java_register_test_runner_api (env);
   frida_java_register_script_api (env);
+  frida_java_register_badger_api (env);
 
   (*env)->PushLocalFrame (env, 7);
 
@@ -260,6 +268,21 @@ frida_java_register_script_api (JNIEnv * env)
   (*env)->DeleteLocalRef (env, script);
 }
 
+static void
+frida_java_register_badger_api (JNIEnv * env)
+{
+  jclass badger;
+  jint result;
+
+  badger = (*env)->FindClass (env, "re/frida/Badger");
+  g_assert (badger != NULL);
+
+  result = (*env)->RegisterNatives (env, badger, re_frida_badger_methods, G_N_ELEMENTS (re_frida_badger_methods));
+  g_assert_cmpint (result, ==, 0);
+
+  (*env)->DeleteLocalRef (env, badger);
+}
+
 static JNIEnv *
 frida_java_get_env (void)
 {
@@ -326,6 +349,12 @@ re_frida_script_create (JNIEnv * env, jobject self, jstring source_code)
   }
 
   return (jlong) op.script;
+}
+
+static void
+re_frida_badger_native_method (JNIEnv * env, jobject self, jstring str)
+{
+    return;
 }
 
 static void

--- a/test/runner.c
+++ b/test/runner.c
@@ -83,7 +83,7 @@ main (int argc, char * argv[])
   jobjectArray argv_value;
   jstring data_dir_value, cache_dir_value;
   guint arg_index;
-  gboolean optimization_enabled = false;
+  gboolean optimization_enabled = FALSE;
 
   gum_init_embedded ();
 
@@ -94,12 +94,10 @@ main (int argc, char * argv[])
 
   js_backend = gum_script_backend_obtain_qjs ();
 
-  if (argc > 1 && strcmp(argv[1], "--enable-optimizations")) {
-    optimization_enabled = true;
+  if (argc > 1 && strcmp (argv[1], "--enable-optimizations") == 0) {
+    optimization_enabled = TRUE;
 
-    // Pop argv[1].
     argv[1] = argv[0];
-
     argc--;
     argv++;
   }
@@ -158,7 +156,7 @@ frida_java_init_vm (JavaVM ** vm, JNIEnv ** env, gboolean optimization_enabled)
   void * vm_module, * runtime_module;
   jint (* create_java_vm) (JavaVM ** vm, JNIEnv ** env, void * vm_args);
   int n_options;
-  JavaVMOption *options;
+  JavaVMOption * options;
   JavaVMInitArgs args;
   jint (* register_natives) (JNIEnv * env);
   jint (* register_natives_legacy) (JNIEnv * env, jclass clazz);
@@ -178,13 +176,12 @@ frida_java_init_vm (JavaVM ** vm, JNIEnv ** env, gboolean optimization_enabled)
   g_assert (create_java_vm != NULL);
 
   n_options = 5;
-  if (optimization_enabled) {
+  if (optimization_enabled)
     n_options += 4;
-  } else {
+  else
     n_options += 1;
-  }
 
-  options = malloc(n_options * sizeof(JavaVMOption));
+  options = g_new0 (JavaVMOption, n_options);
 
   options[0].optionString = "-verbose:jni";
   options[1].optionString = "-verbose:gc";
@@ -192,12 +189,15 @@ frida_java_init_vm (JavaVM ** vm, JNIEnv ** env, gboolean optimization_enabled)
   options[3].optionString = "-Xdebug";
   options[4].optionString = "-Djava.class.path=" FRIDA_JAVA_TESTS_DATA_DIR "/tests.dex";
 
-  if (optimization_enabled) {
+  if (optimization_enabled)
+  {
     options[5].optionString = "-Xcompiler-option";
     options[6].optionString = "--compiler-filter=speed";
     options[7].optionString = "-Xcompiler-option";
     options[8].optionString = "--inline-max-code-units=0";
-  } else {
+  }
+  else
+  {
     options[5].optionString = "-Xint";
   }
 
@@ -209,7 +209,7 @@ frida_java_init_vm (JavaVM ** vm, JNIEnv ** env, gboolean optimization_enabled)
   result = create_java_vm (vm, env, &args);
   g_assert_cmpint (result, ==, JNI_OK);
 
-  free(options);
+  g_free (options);
 
   register_natives = dlsym (runtime_module, "registerFrameworkNatives");
   if (register_natives != NULL)

--- a/test/runner.c
+++ b/test/runner.c
@@ -91,7 +91,7 @@ main (int argc, char * argv[])
   jobjectArray argv_value;
   jstring data_dir_value, cache_dir_value;
   guint arg_index;
-  gboolean enable_optimizations = FALSE;
+  gboolean enable_optimizations;
 
   gum_init_embedded ();
 
@@ -109,6 +109,10 @@ main (int argc, char * argv[])
     argv[1] = argv[0];
     argc--;
     argv++;
+  }
+  else
+  {
+    enable_optimizations = FALSE;
   }
 
   frida_java_init_vm (&vm, &env, enable_optimizations);


### PR DESCRIPTION
- Fix hooking of Interpreter internals on Android 5.0 & 5.1.
- Improve the test suite to include running with optimizations enabled (in-lining optimizations disabled).
- Fail explicitly when hooking an ArtMethod if it's too short and the prologue can't be overwritten, instead of hanging.