### PR TITLE
Fix error: unable to find export '_Znwm'

### DIFF
--- a/lib/jvm.js
+++ b/lib/jvm.js
@@ -275,16 +275,19 @@ function _getApi () {
   }
   temporaryApi.vm = vms.readPointer();
 
-  try {
-    temporaryApi.$new = new NativeFunction(Module.getExportByName(null, '_Znwm'), 'pointer', ['ulong'], nativeFunctionOptions);
-  } catch {
-    temporaryApi.$new = new NativeFunction(ptr(DebugSymbol.fromName('_Znwm').address), 'pointer', ['ulong'], nativeFunctionOptions);
-  }
-  try {
-    temporaryApi.$delete = new NativeFunction(Module.getExportByName(null, '_ZdlPv'), 'void', ['pointer'], nativeFunctionOptions);
-  } catch {
-    temporaryApi.$delete = new NativeFunction(ptr(DebugSymbol.fromName('_ZdlPv').address), 'void', ['pointer'], nativeFunctionOptions);
-  }
+  const exports = {
+    '$new': ['_Znwm', 'pointer', ['ulong']],
+    '$delete': ['_ZdlPv', 'void', ['pointer']]
+  };
+  Object.keys(exports)
+    .forEach(function (name) {
+      const items = exports[name];
+      const addr = Module.findExportByName(null, items[0]) || DebugSymbol.fromName(items[0]).address;
+      if (addr.isNull()) {
+        throw "unable to find items '" + items[0] + "'";
+      }
+      temporaryApi[name] = new NativeFunction(addr, items[1], items[2], nativeFunctionOptions);
+    });
 
   temporaryApi.jvmti = getEnvJvmti(temporaryApi);
   return temporaryApi;

--- a/lib/jvm.js
+++ b/lib/jvm.js
@@ -275,8 +275,16 @@ function _getApi () {
   }
   temporaryApi.vm = vms.readPointer();
 
-  temporaryApi.$new = new NativeFunction(Module.getExportByName(null, '_Znwm'), 'pointer', ['ulong'], nativeFunctionOptions);
-  temporaryApi.$delete = new NativeFunction(Module.getExportByName(null, '_ZdlPv'), 'void', ['pointer'], nativeFunctionOptions);
+  try {
+    temporaryApi.$new = new NativeFunction(Module.getExportByName(null, '_Znwm'), 'pointer', ['ulong'], nativeFunctionOptions);
+  } catch {
+    temporaryApi.$new = new NativeFunction(ptr(DebugSymbol.fromName('_Znwm').address), 'pointer', ['ulong'], nativeFunctionOptions);
+  }
+  try {
+    temporaryApi.$delete = new NativeFunction(Module.getExportByName(null, '_ZdlPv'), 'void', ['pointer'], nativeFunctionOptions);
+  } catch {
+    temporaryApi.$delete = new NativeFunction(ptr(DebugSymbol.fromName('_ZdlPv').address), 'void', ['pointer'], nativeFunctionOptions);
+  }
 
   temporaryApi.jvmti = getEnvJvmti(temporaryApi);
   return temporaryApi;

--- a/lib/jvm.js
+++ b/lib/jvm.js
@@ -284,7 +284,7 @@ function _getApi () {
       const items = exports[name];
       const addr = Module.findExportByName(null, items[0]) || DebugSymbol.fromName(items[0]).address;
       if (addr.isNull()) {
-        throw "unable to find items '" + items[0] + "'";
+        throw "Error: unable to find export '" + items[0] + "'";
       }
       temporaryApi[name] = new NativeFunction(addr, items[1], items[2], nativeFunctionOptions);
     });

--- a/lib/jvm.js
+++ b/lib/jvm.js
@@ -275,19 +275,20 @@ function _getApi () {
   }
   temporaryApi.vm = vms.readPointer();
 
-  const exports = {
-    '$new': ['_Znwm', 'pointer', ['ulong']],
-    '$delete': ['_ZdlPv', 'void', ['pointer']]
+  const allocatorFunctions = {
+    $new: ['_Znwm', 'pointer', ['ulong']],
+    $delete: ['_ZdlPv', 'void', ['pointer']]
   };
-  Object.keys(exports)
-    .forEach(function (name) {
-      const items = exports[name];
-      const addr = Module.findExportByName(null, items[0]) || DebugSymbol.fromName(items[0]).address;
-      if (addr.isNull()) {
-        throw "Error: unable to find export '" + items[0] + "'";
+  for (const [name, [rawName, retType, argTypes]] of Object.entries(allocatorFunctions)) {
+    let address = Module.findExportByName(null, rawName);
+    if (address === null) {
+      address = DebugSymbol.fromName(rawName).address;
+      if (address.isNull()) {
+        throw new Error(`unable to find C++ allocator API, missing: '${rawName}'`);
       }
-      temporaryApi[name] = new NativeFunction(addr, items[1], items[2], nativeFunctionOptions);
-    });
+    }
+    temporaryApi[name] = new NativeFunction(address, retType, argTypes, nativeFunctionOptions);
+  }
 
   temporaryApi.jvmti = getEnvJvmti(temporaryApi);
   return temporaryApi;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
       "Arm64Relocator",
       "Arm64Writer",
       "CModule",
+      "DebugSymbol",
       "File",
       "Instruction",
       "Int64",


### PR DESCRIPTION
When I run `frida` with openjdk-9.x on 64-bit CentOS, this happens:

```console
[Remote::PID::117235]-> Module.enumerateExports(m.path).filter(m=>/_Znwm/.test(m.name))
[]
[Remote::PID::117235]-> Module.enumerateSymbols(m.path).filter(m=>/_Znwm/.test(m.name))
[
    {
        "address": "0x2b7ea13138c0",
        "isGlobal": false,
        "name": "_Znwm",
        "section": {
            "id": "11.text",
            "protection": "r-x"
        },
        "size": 105,
        "type": "function"
    }
]
[Remote::PID::117235]-> DebugSymbol.fromName('_Znwm')
{
    "address": "0x2b7ea13138c0",
    "fileName": "",
    "lineNumber": 0,
    "moduleName": "libjvm.so",
    "name": "_Znwm"
}
```

I haven't looked into gum/gumJS to find out what caused this, but this makes frida error out whenever `Java.*` is used:

```console
Error: unable to find export '_Znwm'
```

The exact JDK I used was [9.0.4](https://download.java.net/java/GA/jdk9/9.0.4/binaries/openjdk-9.0.4_linux-x64_bin.tar.gz), which you can download from [this page](https://jdk.java.net/archive/).

I have tested the PR code using [this setup](https://gist.github.com/oleavr/cae76c895eb7d227216ed3ffe9dbbeb3) on the aforementioned JDK, and it worked.