### PR TITLE
add Java.deoptimizeMethod to call art::Dbg::RequestDeoptimization

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ const {
   makeArtClassVisitor,
   makeArtClassLoaderVisitor,
   deoptimizeEverything,
-  deoptimizeBootImage
+  deoptimizeBootImage,
+  deoptimizeMethod
 } = require('./lib/android');
 const ClassFactory = require('./lib/class-factory');
 const ClassModel = require('./lib/class-model');
@@ -500,6 +501,11 @@ class Runtime {
   deoptimizeBootImage () {
     const { vm } = this;
     return deoptimizeBootImage(vm, vm.getEnv());
+  }
+
+  deoptimizeMethod (className, methodName, description) {
+    const { vm } = this;
+    return deoptimizeMethod(vm, vm.getEnv(), className, methodName, description);
   }
 
   _checkAvailable () {

--- a/index.js
+++ b/index.js
@@ -503,9 +503,9 @@ class Runtime {
     return deoptimizeBootImage(vm, vm.getEnv());
   }
 
-  deoptimizeMethod (className, methodName, description) {
+  deoptimizeMethod (method) {
     const { vm } = this;
-    return deoptimizeMethod(vm, vm.getEnv(), className, methodName, description);
+    return deoptimizeMethod(vm, vm.getEnv(), method);
   }
 
   _checkAvailable () {

--- a/lib/android.js
+++ b/lib/android.js
@@ -2563,16 +2563,20 @@ function cloneArtMethod (method, vm) {
   return Memory.dup(method, getArtMethodSpec(vm).size);
 }
 
-function deoptimizeMethod (vm, env, className, methodName, description) {
+const kNothing = 0;
+const kRegisterForEvent = 1;
+const kUnregisterForEvent = 2;
+const kFullDeoptimization = 3;
+const kFullUndeoptimization = 4
+const kSelectiveDeoptimization = 5;
+const kSelectiveUndeoptimization = 6;
+
+function requestDeoptimization (vm, env, args) {
   const api = getApi();
 
   if (getAndroidApiLevel() < 24) {
     throw new Error('This API is only available on Nougat and above');
   }
-
-  const clazz = env.findClass(className);
-  const methodID = env.getMethodId(clazz, methodName, description);
-  const artMehtod = unwrapMethodId(methodID);
 
   withRunnableArtThread(vm, env, thread => {
     if (getAndroidApiLevel() < 30) {
@@ -2585,10 +2589,20 @@ function deoptimizeMethod (vm, env, className, methodName, description) {
         api['art::Dbg::GoActive']();
       }
 
-      const kSelectiveDeoptimization = 5;
+      const deoptimizeKey = args['deoptimizeKey'];
+
       const request = Memory.alloc(8 + pointerSize);
-      request.writeU32(kSelectiveDeoptimization);
-      request.add(8).writePointer(artMehtod);
+      request.writeU32(deoptimizeKey);
+
+      switch (deoptimizeKey) {
+        case kFullDeoptimization:
+          break;
+        case kSelectiveDeoptimization:
+          request.add(8).writePointer(args['method']);
+          break;
+        default:
+          throw new Error('deoptimizeKey ' + deoptimizeKey + ' is not support');
+      }
 
       api['art::Dbg::RequestDeoptimization'](request);
 
@@ -2604,49 +2618,29 @@ function deoptimizeMethod (vm, env, className, methodName, description) {
         api['art::Instrumentation::EnableDeoptimization'](instrumentation);
       }
 
-      api['art::Instrumentation::Deoptimize'](instrumentation, artMehtod);
+      switch (deoptimizeKey) {
+        case kFullDeoptimization:
+          api['art::Instrumentation::DeoptimizeEverything'](instrumentation, Memory.allocUtf8String('frida'));
+          break;
+        case kSelectiveDeoptimization:
+          api['art::Instrumentation::Deoptimize'](instrumentation, args['method']);
+          break;
+        default:
+          throw new Error('deoptimizeKey ' + deoptimizeKey + ' is not support');
+      }
+
     }
   });
 }
 
+function deoptimizeMethod (vm, env, method) {
+  const args = {'method' : method, 'deoptimizeKey' : kSelectiveDeoptimization};
+  requestDeoptimization(vm, env, args);
+}
+
 function deoptimizeEverything (vm, env) {
-  const api = getApi();
-
-  if (getAndroidApiLevel() < 24) {
-    throw new Error('This API is only available on Nougat and above');
-  }
-
-  withRunnableArtThread(vm, env, thread => {
-    if (getAndroidApiLevel() < 30) {
-      if (!api.isJdwpStarted()) {
-        const session = startJdwp(api);
-        jdwpSessions.push(session);
-      }
-
-      if (!api.isDebuggerActive()) {
-        api['art::Dbg::GoActive']();
-      }
-
-      const kFullDeoptimization = 3;
-      const request = Memory.alloc(8 + pointerSize);
-      request.writeU32(kFullDeoptimization);
-      api['art::Dbg::RequestDeoptimization'](request);
-
-      api['art::Dbg::ManageDeoptimization']();
-    } else {
-      const instrumentation = api.artInstrumentation;
-      if (instrumentation === null) {
-        throw new Error('Unable to find Instrumentation class in ART; please file a bug');
-      }
-
-      const deoptimizationEnabled = !!instrumentation.add(getArtInstrumentationSpec().offset.deoptimizationEnabled).readU8();
-      if (!deoptimizationEnabled) {
-        api['art::Instrumentation::EnableDeoptimization'](instrumentation);
-      }
-
-      api['art::Instrumentation::DeoptimizeEverything'](instrumentation, Memory.allocUtf8String('frida'));
-    }
-  });
+  const args = {'deoptimizeKey' : kFullDeoptimization};
+  requestDeoptimization(vm, env, args);
 }
 
 function deoptimizeBootImage (vm, env) {

--- a/lib/android.js
+++ b/lib/android.js
@@ -26,6 +26,9 @@ const kAccXposedHookedMethod = 0x10000000;
 
 const kPointer = 0x0;
 
+const kFullDeoptimization = 3;
+const kSelectiveDeoptimization = 5;
+
 const THUMB_BIT_REMOVAL_MASK = ptr(1).not();
 
 const X86_JMP_MAX_DISTANCE = 0x7fffbfff;
@@ -2563,15 +2566,23 @@ function cloneArtMethod (method, vm) {
   return Memory.dup(method, getArtMethodSpec(vm).size);
 }
 
-const kNothing = 0;
-const kRegisterForEvent = 1;
-const kUnregisterForEvent = 2;
-const kFullDeoptimization = 3;
-const kFullUndeoptimization = 4
-const kSelectiveDeoptimization = 5;
-const kSelectiveUndeoptimization = 6;
+function deoptimizeMethod (vm, env, method) {
+  requestDeoptimization(vm, env, kSelectiveDeoptimization, method);
+}
 
-function requestDeoptimization (vm, env, args) {
+function deoptimizeEverything (vm, env) {
+  requestDeoptimization(vm, env, kFullDeoptimization);
+}
+
+function deoptimizeBootImage (vm, env) {
+  const api = getApi();
+
+  withRunnableArtThread(vm, env, thread => {
+    api['art::Runtime::DeoptimizeBootImage'](api.artRuntime);
+  });
+}
+
+function requestDeoptimization (vm, env, kind, method) {
   const api = getApi();
 
   if (getAndroidApiLevel() < 24) {
@@ -2589,19 +2600,17 @@ function requestDeoptimization (vm, env, args) {
         api['art::Dbg::GoActive']();
       }
 
-      const deoptimizeKey = args['deoptimizeKey'];
-
       const request = Memory.alloc(8 + pointerSize);
-      request.writeU32(deoptimizeKey);
+      request.writeU32(kind);
 
-      switch (deoptimizeKey) {
+      switch (kind) {
         case kFullDeoptimization:
           break;
         case kSelectiveDeoptimization:
-          request.add(8).writePointer(args['method']);
+          request.add(8).writePointer(method);
           break;
         default:
-          throw new Error('deoptimizeKey ' + deoptimizeKey + ' is not support');
+          throw new Error('Unsupported deoptimization kind');
       }
 
       api['art::Dbg::RequestDeoptimization'](request);
@@ -2618,36 +2627,18 @@ function requestDeoptimization (vm, env, args) {
         api['art::Instrumentation::EnableDeoptimization'](instrumentation);
       }
 
-      switch (deoptimizeKey) {
+      switch (kind) {
         case kFullDeoptimization:
           api['art::Instrumentation::DeoptimizeEverything'](instrumentation, Memory.allocUtf8String('frida'));
           break;
         case kSelectiveDeoptimization:
-          api['art::Instrumentation::Deoptimize'](instrumentation, args['method']);
+          api['art::Instrumentation::Deoptimize'](instrumentation, method);
           break;
         default:
-          throw new Error('deoptimizeKey ' + deoptimizeKey + ' is not support');
+          throw new Error('Unsupported deoptimization kind');
       }
 
     }
-  });
-}
-
-function deoptimizeMethod (vm, env, method) {
-  const args = {'method' : method, 'deoptimizeKey' : kSelectiveDeoptimization};
-  requestDeoptimization(vm, env, args);
-}
-
-function deoptimizeEverything (vm, env) {
-  const args = {'deoptimizeKey' : kFullDeoptimization};
-  requestDeoptimization(vm, env, args);
-}
-
-function deoptimizeBootImage (vm, env) {
-  const api = getApi();
-
-  withRunnableArtThread(vm, env, thread => {
-    api['art::Runtime::DeoptimizeBootImage'](api.artRuntime);
   });
 }
 

--- a/lib/android.js
+++ b/lib/android.js
@@ -2637,7 +2637,6 @@ function requestDeoptimization (vm, env, kind, method) {
         default:
           throw new Error('Unsupported deoptimization kind');
       }
-
     }
   });
 }

--- a/lib/android.js
+++ b/lib/android.js
@@ -275,6 +275,7 @@ function _getApi () {
             };
           },
           _ZN3art7Runtime19DeoptimizeBootImageEv: ['art::Runtime::DeoptimizeBootImage', 'void', ['pointer']],
+          _ZN3art15instrumentation15Instrumentation10DeoptimizeEPNS_9ArtMethodE: ['art::Instrumentation::Deoptimize', 'void', ['pointer', 'pointer']],
 
           // Android >= 11
           _ZN3art3jni12JniIdManager14DecodeMethodIdEP10_jmethodID: ['art::jni::JniIdManager::DecodeMethodId', 'pointer', ['pointer', 'pointer']],
@@ -323,6 +324,7 @@ function _getApi () {
           '_ZN3art15instrumentation15Instrumentation20DeoptimizeEverythingEPKc',
           '_ZN3art15instrumentation15Instrumentation20DeoptimizeEverythingEv',
           '_ZN3art7Runtime19DeoptimizeBootImageEv',
+          '_ZN3art15instrumentation15Instrumentation10DeoptimizeEPNS_9ArtMethodE',
           '_ZN3art3Dbg9StartJdwpEv',
           '_ZN3art3Dbg8GoActiveEv',
           '_ZN3art3Dbg21RequestDeoptimizationERKNS_21DeoptimizationRequestE',
@@ -2561,6 +2563,52 @@ function cloneArtMethod (method, vm) {
   return Memory.dup(method, getArtMethodSpec(vm).size);
 }
 
+function deoptimizeMethod (vm, env, className, methodName, description) {
+  const api = getApi();
+
+  if (getAndroidApiLevel() < 24) {
+    throw new Error('This API is only available on Nougat and above');
+  }
+
+  const clazz = env.findClass(className);
+  const methodID = env.getMethodId(clazz, methodName, description);
+  const artMehtod = unwrapMethodId(methodID);
+
+  withRunnableArtThread(vm, env, thread => {
+    if (getAndroidApiLevel() < 30) {
+      if (!api.isJdwpStarted()) {
+        const session = startJdwp(api);
+        jdwpSessions.push(session);
+      }
+
+      if (!api.isDebuggerActive()) {
+        api['art::Dbg::GoActive']();
+      }
+
+      const kSelectiveDeoptimization = 5;
+      const request = Memory.alloc(8 + pointerSize);
+      request.writeU32(kSelectiveDeoptimization);
+      request.add(8).writePointer(artMehtod);
+
+      api['art::Dbg::RequestDeoptimization'](request);
+
+      api['art::Dbg::ManageDeoptimization']();
+    } else {
+      const instrumentation = api.artInstrumentation;
+      if (instrumentation === null) {
+        throw new Error('Unable to find Instrumentation class in ART; please file a bug');
+      }
+
+      const deoptimizationEnabled = !!instrumentation.add(getArtInstrumentationSpec().offset.deoptimizationEnabled).readU8();
+      if (!deoptimizationEnabled) {
+        api['art::Instrumentation::EnableDeoptimization'](instrumentation);
+      }
+
+      api['art::Instrumentation::Deoptimize'](instrumentation, artMehtod);
+    }
+  });
+}
+
 function deoptimizeEverything (vm, env) {
   const api = getApi();
 
@@ -4011,6 +4059,7 @@ module.exports = {
   revertGlobalPatches,
   deoptimizeEverything,
   deoptimizeBootImage,
+  deoptimizeMethod,
   HandleVector,
   VariableSizedHandleScope,
   makeObjectVisitorPredicate,


### PR DESCRIPTION
add Java.deoptimizeMethod to call art::Dbg::RequestDeoptimization with selectiveDeoptimizaion option to deoptimize specific method.

This PR can provide frida to deoptimize specific method for the situation that specific method hooking is not taken effect. This will reduce the overhead for turn on all the deoptimizations and keep the app's running performance.