### PR TITLE
Fix hooking of ART interpreter internals.

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -1598,6 +1598,21 @@ on_art_method_pretty_method (GumInvocationContext * ic)
   else
     last_seen_art_method = method;
 }
+
+void
+on_leave_gc_concurrent_copying_copying_phase (GumInvocationContext * ic)
+{
+  GHashTableIter iter;
+  gpointer hooked_method, replacement_method;
+
+  g_mutex_lock (&lock);
+
+  g_hash_table_iter_init (&iter, methods);
+  while (g_hash_table_iter_next (&iter, &hooked_method, &replacement_method))
+    *((uint32_t *) replacement_method) = *((uint32_t *) hooked_method);
+
+  g_mutex_unlock (&lock);
+}
 `;
 
   const lockSize = 8;
@@ -1643,6 +1658,11 @@ on_art_method_pretty_method (GumInvocationContext * ic)
       ArtMethod: {
         getOatQuickMethodHeader: cm.on_art_method_get_oat_quick_method_header,
         prettyMethod: cm.on_art_method_pretty_method
+      },
+      Gc: {
+        copyingPhase: {
+          onLeave: cm.on_leave_gc_concurrent_copying_copying_phase
+        }
       }
     }
   };
@@ -1658,20 +1678,14 @@ function ensureArtKnowsHowToHandleMethodInstrumentation (vm) {
   instrumentArtMethodInvocationFromInterpreter();
 }
 
-/* Entrypoints that dispatch method invocation from the quick ABI. */
 function instrumentArtQuickEntrypoints (vm) {
   const api = getApi();
 
+  // Entrypoints that dispatch method invocation from the quick ABI.
   const quickEntrypoints = [
     api.artQuickGenericJniTrampoline,
     api.artQuickToInterpreterBridge
   ];
-
-  const { artNterpEntryPoint } = api;
-
-  if (artNterpEntryPoint !== undefined && !artNterpEntryPoint.equals(NULL)) {
-    quickEntrypoints.push(artNterpEntryPoint);
-  }
 
   quickEntrypoints.forEach(entrypoint => {
     Memory.protect(entrypoint, 32, 'rwx');
@@ -1686,14 +1700,14 @@ function instrumentArtQuickEntrypoints (vm) {
 function instrumentArtMethodInvocationFromInterpreter () {
   const apiLevel = getAndroidApiLevel();
 
-  let artInterpreterDoCallSymbolRegex;
+  let artInterpreterDoCallExportRegex;
   if (apiLevel <= 22) {
-    artInterpreterDoCallSymbolRegex = /^_ZN3art11interpreter6DoCallILb[0-1]ELb[0-1]EEEbPNS_6mirror9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtPNS_6JValueE$/;
+    artInterpreterDoCallExportRegex = /^_ZN3art11interpreter6DoCallILb[0-1]ELb[0-1]EEEbPNS_6mirror9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtPNS_6JValueE$/;
   } else {
-    artInterpreterDoCallSymbolRegex = /^_ZN3art11interpreter6DoCallILb[0-1]ELb[0-1]EEEbPNS_9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtPNS_6JValueE$/;
+    artInterpreterDoCallExportRegex = /^_ZN3art11interpreter6DoCallILb[0-1]ELb[0-1]EEEbPNS_9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtPNS_6JValueE$/;
   }
 
-  for (const exp of Module.enumerateExports('libart.so').filter(exp => artInterpreterDoCallSymbolRegex.test(exp.name))) {
+  for (const exp of Module.enumerateExports('libart.so').filter(exp => artInterpreterDoCallExportRegex.test(exp.name))) {
     Interceptor.attach(exp.address, artController.hooks.Interpreter.doCall);
   }
 }
@@ -1716,6 +1730,19 @@ function ensureArtKnowsHowToHandleReplacementMethods (vm) {
      * Already replaced by another script. For now we don't support replacing methods from multiple scripts,
      * but we'll allow users to try it if they're feeling adventurous.
      */
+  }
+
+  const apiLevel = getAndroidApiLevel();
+
+  let exportName = null;
+  if (apiLevel > 28) {
+    exportName = '_ZN3art2gc9collector17ConcurrentCopying12CopyingPhaseEv';
+  } else if (apiLevel > 22) {
+    exportName = '_ZN3art2gc9collector17ConcurrentCopying12MarkingPhaseEv';
+  }
+
+  if (exportName !== null) {
+    Interceptor.attach(Module.getExportByName('libart.so', exportName), artController.hooks.Gc.copyingPhase);
   }
 }
 


### PR DESCRIPTION
Since the replacement method that gets allocated by us is not visible to the ART runtime, it therefore
cannot be candidate for garbage collector visits when sweeps occur. In that case, the declaring_class_
field of ArtMethod (a GC root) could become stale after it gets moved to another memory space - resulting
in a crash when it is used after the fact.

Fixes https://github.com/frida/frida/issues/1609.