### PR TITLE
Fix result of Java.enumerateMethods on ART

### DIFF
--- a/lib/class-model.js
+++ b/lib/class-model.js
@@ -599,6 +599,12 @@ collect_matching_class_methods (ArtClassVisitor * self,
     }
     else
     {
+      const gchar * name_begin;
+
+      name_begin = bare_method_name + class_name_length + 1;
+      if (is_constructor && g_str_has_prefix (name_begin, "<clinit>"))
+        goto skip_method;
+
       if (is_constructor)
         bare_method_name = "$init";
       else

--- a/lib/class-model.js
+++ b/lib/class-model.js
@@ -602,7 +602,7 @@ collect_matching_class_methods (ArtClassVisitor * self,
       const gchar * name_begin;
 
       name_begin = bare_method_name + class_name_length + 1;
-      if (is_constructor && g_str_has_prefix (name_begin, "<clinit>"))
+      if (is_constructor && strcmp (name_begin, "<clinit>") == 0)
         goto skip_method;
 
       if (is_constructor)


### PR DESCRIPTION
This is a bug where static initializer methods are being included in the enumerated set as '$init' while they should be skipped altogether.