### PR TITLE
Fix handling of generic array types

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -429,89 +429,69 @@ function getArrayType (typeName, unbox, factory) {
       });
     },
     fromJni (arr, env, owned) {
-      // We'll ignore the owned hint as we might otherwise run out of local references.
-      return fromJniObjectArray(arr, env, function (self, elem) {
-        return elementType.fromJni(elem, env);
-      }, owned);
+      if (arr.isNull()) {
+        return null;
+      }
+
+      const result = [];
+
+      const n = env.getArrayLength(arr);
+      for (let i = 0; i !== n; i++) {
+        const element = env.getObjectArrayElement(arr, i);
+        try {
+          // We'll ignore the owned hint as we might otherwise run out of local references.
+          result.push(elementType.fromJni(element, env));
+        } finally {
+          env.deleteLocalRef(element);
+        }
+      }
+
+      result.$w = factory.cast(arr, factory.use(typeName), owned);
+
+      result.$dispose = disposeObjectArray;
+
+      return result;
     },
     toJni (elements, env) {
-      const klassObj = factory.use(elementTypeName);
+      if (elements === null) {
+        return NULL;
+      }
 
+      if (!(elements instanceof Array)) {
+        throw new Error('Expected an array');
+      }
+
+      const wrapper = elements.$w;
+      if (wrapper !== undefined) {
+        return wrapper.$h;
+      }
+
+      const n = elements.length;
+
+      const klassObj = factory.use(elementTypeName);
       const classHandle = klassObj.$borrowClassHandle(env);
       try {
-        return toJniObjectArray(elements, env, classHandle.value,
-          function (i, result) {
-            const handle = elementType.toJni(elements[i], env);
-            try {
-              env.setObjectArrayElement(result, i, handle);
-            } finally {
-              if (elementType.type === 'pointer' && env.getObjectRefType(handle) === JNILocalRefType) {
-                env.deleteLocalRef(handle);
-              }
+        const result = env.newObjectArray(n, classHandle.value, NULL);
+        env.throwIfExceptionPending();
+
+        for (let i = 0; i !== n; i++) {
+          const handle = elementType.toJni(elements[i], env);
+          try {
+            env.setObjectArrayElement(result, i, handle);
+          } finally {
+            if (elementType.type === 'pointer' && env.getObjectRefType(handle) === JNILocalRefType) {
+              env.deleteLocalRef(handle);
             }
-          });
+          }
+          env.throwIfExceptionPending();
+        }
+
+        return result;
       } finally {
         classHandle.unref(env);
       }
     }
   };
-}
-
-function fromJniObjectArray (arr, env, fromJni, owned = true) {
-  if (arr.isNull()) {
-    return null;
-  }
-
-  const result = [];
-
-  const n = env.getArrayLength(arr);
-  for (let i = 0; i !== n; i++) {
-    const element = env.getObjectArrayElement(arr, i);
-    try {
-      result.push(fromJni(this, element));
-    } finally {
-      env.deleteLocalRef(element);
-    }
-  }
-
-  if (owned) {
-    const h = env.newGlobalRef(arr);
-    result.$h = h;
-    result.$r = WeakRef.bind(result, env.vm.makeHandleDestructor(h));
-  } else {
-    result.$h = arr;
-    result.$r = null;
-  }
-
-  result.$dispose = disposeObjectArray;
-
-  return result;
-}
-
-function toJniObjectArray (arr, env, classHandle, setObjectArrayFunc) {
-  if (arr === null) {
-    return NULL;
-  }
-
-  if (!(arr instanceof Array)) {
-    throw new Error('Expected an array');
-  }
-
-  if (arr.$h !== undefined) {
-    return arr.$h;
-  }
-
-  const n = arr.length;
-
-  const result = env.newObjectArray(n, classHandle, NULL);
-  env.throwIfExceptionPending();
-
-  for (let i = 0; i !== n; i++) {
-    setObjectArrayFunc.call(env, i, result);
-    env.throwIfExceptionPending();
-  }
-
-  return result;
 }
 
 function disposeObjectArray () {
@@ -531,10 +511,12 @@ function disposeObjectArray () {
     dispose.call(obj);
   }
 
-  const ref = this.$r;
-  if (ref) {
-    this.$r = null;
-    WeakRef.unbind(ref);
+  const wrapper = this.$w;
+  if (wrapper !== undefined) {
+    const dispose = wrapper.$dispose;
+    if (dispose !== undefined) {
+      dispose.call(wrapper);
+    }
   }
 }
 

--- a/lib/types.js
+++ b/lib/types.js
@@ -511,8 +511,7 @@ function disposeObjectArray () {
     dispose.call(obj);
   }
 
-  const wrapper = this.$w;
-  wrapper?.$dispose.call(wrapper);
+  this.$w.$dispose();
 }
 
 function fromJniPrimitiveArray (arr, spec, env, owned) {

--- a/lib/types.js
+++ b/lib/types.js
@@ -512,12 +512,7 @@ function disposeObjectArray () {
   }
 
   const wrapper = this.$w;
-  if (wrapper !== undefined) {
-    const dispose = wrapper.$dispose;
-    if (dispose !== undefined) {
-      dispose.call(wrapper);
-    }
-  }
+  wrapper?.$dispose?.call(wrapper);
 }
 
 function fromJniPrimitiveArray (arr, spec, env, owned) {

--- a/lib/types.js
+++ b/lib/types.js
@@ -512,7 +512,7 @@ function disposeObjectArray () {
   }
 
   const wrapper = this.$w;
-  wrapper?.$dispose?.call(wrapper);
+  wrapper?.$dispose.call(wrapper);
 }
 
 function fromJniPrimitiveArray (arr, spec, env, owned) {

--- a/lib/types.js
+++ b/lib/types.js
@@ -432,7 +432,7 @@ function getArrayType (typeName, unbox, factory) {
       // We'll ignore the owned hint as we might otherwise run out of local references.
       return fromJniObjectArray(arr, env, function (self, elem) {
         return elementType.fromJni(elem, env);
-      });
+      }, owned);
     },
     toJni (elements, env) {
       const klassObj = factory.use(elementTypeName);
@@ -457,7 +457,7 @@ function getArrayType (typeName, unbox, factory) {
   };
 }
 
-function fromJniObjectArray (arr, env, fromJni) {
+function fromJniObjectArray (arr, env, fromJni, owned = true) {
   if (arr.isNull()) {
     return null;
   }
@@ -474,6 +474,15 @@ function fromJniObjectArray (arr, env, fromJni) {
     }
   }
 
+  if (owned) {
+    const h = env.newGlobalRef(arr);
+    result.$h = h;
+    result.$r = WeakRef.bind(result, env.vm.makeHandleDestructor(h));
+  } else {
+    result.$h = arr;
+    result.$r = null;
+  }
+
   result.$dispose = disposeObjectArray;
 
   return result;
@@ -486,6 +495,10 @@ function toJniObjectArray (arr, env, classHandle, setObjectArrayFunc) {
 
   if (!(arr instanceof Array)) {
     throw new Error('Expected an array');
+  }
+
+  if (arr.$h !== undefined) {
+    return arr.$h;
   }
 
   const n = arr.length;
@@ -516,6 +529,12 @@ function disposeObjectArray () {
       break;
     }
     dispose.call(obj);
+  }
+
+  const ref = this.$r;
+  if (ref) {
+    this.$r = null;
+    WeakRef.unbind(ref);
   }
 }
 

--- a/test/re/frida/MethodTest.java
+++ b/test/re/frida/MethodTest.java
@@ -10,6 +10,8 @@ import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.lang.UnsupportedOperationException;
+import java.lang.ClassCastException;
+import java.lang.reflect.Array;
 import javax.crypto.Cipher;
 
 public class MethodTest {
@@ -519,6 +521,21 @@ public class MethodTest {
         assertEquals("randomString", script.getNextMessage());
     }
 
+    @Test
+    public void genericArrayTypeShouldBePreserved() {
+        loadScript("var GenericArray = Java.use('re.frida.GenericArray');" +
+                "var getArray2 = GenericArray.getArray2;" +
+                "getArray2.implementation = function (clazz) {" +
+                    "return getArray2.call(this, clazz);" +
+                "};");
+
+        try {
+            String[] arr = GenericArray.getArray2(String.class);
+        } catch (ClassCastException e) {
+            fail(e.toString());
+        }
+    }
+
     private Script script = null;
 
     private void loadScript(String code) {
@@ -711,5 +728,10 @@ class Reflector {
 class GenericArray {
     public static Class<?>[] getArray() {
         return new Class<?>[] { Collider.class, Reflector.class };
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T[] getArray2(Class<T> clazz) {
+        return (T[]) Array.newInstance(clazz, 1);
     }
 }

--- a/test/re/frida/MethodTest.java
+++ b/test/re/frida/MethodTest.java
@@ -9,8 +9,8 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
-import java.lang.UnsupportedOperationException;
 import java.lang.ClassCastException;
+import java.lang.UnsupportedOperationException;
 import java.lang.reflect.Array;
 import javax.crypto.Cipher;
 
@@ -523,8 +523,8 @@ public class MethodTest {
 
     @Test
     public void genericArrayTypeShouldBePreserved() {
-        loadScript("var GenericArray = Java.use('re.frida.GenericArray');" +
-                "var getArray2 = GenericArray.getArray2;" +
+        loadScript("const GenericArray = Java.use('re.frida.GenericArray');" +
+                "const getArray2 = GenericArray.getArray2;" +
                 "getArray2.implementation = function (clazz) {" +
                     "return getArray2.call(this, clazz);" +
                 "};");


### PR DESCRIPTION
This allows array objects obtained from the runtime to be reused later when marshaling array types, which is necessary in order to preserve type information in cases where the type is dynamic.