### PR TITLE
Remove kAccSingleImplementation flag to avoid method being devirtualized

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -21,6 +21,7 @@ const kAccFastNative = 0x00080000;
 const kAccCriticalNative = 0x00200000;
 const kAccFastInterpreterToInterpreterInvoke = 0x40000000;
 const kAccSkipAccessChecks = 0x00080000;
+const kAccSingleImplementation = 0x08000000;
 const kAccPublicApi = 0x10000000;
 const kAccXposedHookedMethod = 0x10000000;
 
@@ -2315,7 +2316,7 @@ class ArtMethodMangler {
 
     // Remove kAccFastInterpreterToInterpreterInvoke and kAccSkipAccessChecks to disable use_fast_path
     // in interpreter_common.h
-    let hookedMethodRemovedFlags = kAccFastInterpreterToInterpreterInvoke;
+    let hookedMethodRemovedFlags = kAccFastInterpreterToInterpreterInvoke | kAccSingleImplementation;
     if ((originalFlags & kAccNative) === 0) {
       hookedMethodRemovedFlags |= kAccSkipAccessChecks;
     }


### PR DESCRIPTION
Remove kAccSingleImplementation flag to avoid method being devirtualized so that frida can hook the method correctly