### PR TITLE
Fix Java.array for unloaded array types

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -446,7 +446,15 @@ function getArrayType (typeName, unbox, factory) {
         }
       }
 
-      result.$w = factory.cast(arr, factory.use(typeName), owned);
+      // The type name we get is not always the correct representation of the type so we make it so here.
+      const internalTypeName = '[L' + elementTypeName.replace(/\./g, '/') + ';';
+      try {
+        result.$w = factory.cast(arr, factory.use(internalTypeName), owned);
+      } catch (e) {
+        // We need to load the array type before using it.
+        factory.use('java.lang.reflect.Array').newInstance(factory.use(elementTypeName).class, 0);
+        result.$w = factory.cast(arr, factory.use(internalTypeName), owned);
+      }
 
       result.$dispose = disposeObjectArray;
 


### PR DESCRIPTION
If the type of the array was not used in the application it means that it wasn't loaded in memory and Java.array failed because of this. This fix tries first to use the array type and if it fail, it will first create an empty array of that type using java.lang.reflect.Array.newInstance before calling factory.use.