### PR TITLE
Expose JNIEnv->GetDirectBufferAddress to JS

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -531,6 +531,10 @@ Env.prototype.monitorExit = proxy(218, 'int32', ['pointer', 'pointer'], function
   return impl(this.handle, obj);
 });
 
+Env.prototype.getDirectBufferAddress = proxy(230, 'pointer', ['pointer', 'pointer'], function (impl, obj) {
+  return impl(this.handle, obj);
+});
+
 Env.prototype.getObjectRefType = proxy(232, 'int32', ['pointer', 'pointer'], function (impl, ref) {
   return impl(this.handle, ref);
 });


### PR DESCRIPTION
A number of `JNIEnv` functions are currently exposed via the object returned by `Java.vm.getEnv()`, however `GetDirectBufferAddress` is missing.

This function is used when you need to share a raw byte buffer between managed and unmanaged code. In Frida, having it allows you to do heavy processing on Java's ByteBuffers via CModules when JS is just not fast enough, e.g. when hooking very hot media processing functions.

See https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/functions.html#GetDirectBufferAddress
and https://developer.android.com/reference/java/nio/ByteBuffer#direct-vs.-non-direct-buffers for more information on direct byte buffers.