### PR TITLE
Always prepend underscores to field names

### DIFF
--- a/lib/class-model.js
+++ b/lib/class-model.js
@@ -409,6 +409,7 @@ model_add_field (Model * self,
 {
   GHashTable * members = self->members;
   gchar * key, type;
+  int prepended_underscore = FALSE;
 
   key = g_strdup (name);
   while (g_hash_table_contains (members, key))
@@ -416,11 +417,19 @@ model_add_field (Model * self,
     gchar * new_key = g_strdup_printf ("_%s", key);
     g_free (key);
     key = new_key;
+    prepended_underscore = TRUE;
   }
 
   type = (modifiers & kAccStatic) != 0 ? 's' : 'i';
 
   g_hash_table_insert (members, key, g_strdup_printf ("f:%c0x%zx", type, id));
+
+  if (!prepended_underscore) {
+    gchar * extra_underscore_key = g_strdup_printf ("_%s", key);
+    if (!g_hash_table_contains (members, extra_underscore_key)) {
+      g_hash_table_insert (members, extra_underscore_key, g_strdup_printf ("f:%c0x%zx", type, id));
+    }
+  }
 }
 
 static void


### PR DESCRIPTION
Because of the way Frida resolve name conflicts, it can be hard to determine the name of a field in Frida. To prevent this, this patch make the naming of fields consistent (as long as there isn't another conflict).

Resolve #240