### PR TITLE
Fix "$" method name is not handled correctly

### DIFF
--- a/lib/class-model.js
+++ b/lib/class-model.js
@@ -390,7 +390,10 @@ model_add_method (Model * self,
   gchar * key, type;
   const gchar * value;
 
-  key = g_strdup (name);
+  if (name[0] == '$')
+    key = g_strdup_printf ("_%s", name);
+  else
+    key = g_strdup (name);
 
   type = (modifiers & kAccStatic) != 0 ? 's' : 'i';
 
@@ -410,7 +413,10 @@ model_add_field (Model * self,
   GHashTable * members = self->members;
   gchar * key, type;
 
-  key = g_strdup (name);
+  if (name[0] == '$')
+    key = g_strdup_printf ("_%s", name);
+  else
+    key = g_strdup (name);
   while (g_hash_table_contains (members, key))
   {
     gchar * new_key = g_strdup_printf ("_%s", key);

--- a/test/re/frida/MethodTest.java
+++ b/test/re/frida/MethodTest.java
@@ -426,6 +426,15 @@ public class MethodTest {
     }
 
     @Test
+    public void dollarPrefixedNamesShouldBeHandled() {
+        loadScript("const DN = Java.use('re.frida.DollarNames');" +
+                "send(DN._$h.value);" +
+                "send(DN._$());");
+        assertEquals("1337", script.getNextMessage());
+        assertEquals("42", script.getNextMessage());
+    }
+
+    @Test
     public void staticFieldCanBeRead() {
         loadScript("var Cipher = Java.use('javax.crypto.Cipher');" +
                 "send('' + Cipher.ENCRYPT_MODE.value);");
@@ -717,6 +726,14 @@ class Collider {
 
     public static int particle2() {
         return 4;
+    }
+}
+
+class DollarNames {
+    public static int $h = 1337;
+
+    public static int $() {
+        return 42;
     }
 }
 


### PR DESCRIPTION
If "$" is used as a method name get function of wrapper does not handle it correctly.  This fixes the issue. I also added test for this. Not sure it is necessary

For the record malware packers use "$" as string decryption function name to avoid being hooked by frida :)
![dollarsign](https://user-images.githubusercontent.com/21275072/154173881-34936918-a411-414a-b458-db6dc21dfcca.png)
