### PR TITLE
frida-trace: improve error message for Java method searching

### DIFF
--- a/lib/class-model.js
+++ b/lib/class-model.js
@@ -1176,7 +1176,7 @@ class Model {
 
     const params = query.match(methodQueryPattern);
     if (params === null) {
-      throw new Error('Invalid method query');
+      throw new Error('Invalid method query - expected: class!method see documentation of Java.enumerateMethods(query) for details');
     }
 
     const classQuery = Memory.allocUtf8String(params[1]);

--- a/lib/class-model.js
+++ b/lib/class-model.js
@@ -1176,7 +1176,7 @@ class Model {
 
     const params = query.match(methodQueryPattern);
     if (params === null) {
-      throw new Error('Invalid method query - expected: class!method see documentation of Java.enumerateMethods(query) for details');
+      throw new Error('Invalid query; format is: class!method -- see documentation of Java.enumerateMethods(query) for details');
     }
 
     const classQuery = Memory.allocUtf8String(params[1]);


### PR DESCRIPTION
As shown by [#1644](https://github.com/frida/frida/issues/1644) the error message `Error: Invalid method query` is not really helpful as it does not give any hint how to change the method query parameter to make frida-trace accept it. 

I noticed that the pattern format is described in the [Java.enumerateMethods](https://frida.re/docs/javascript-api/#java) documentation so in my opinion we should change the error message to contain the basic pattern plus a hint where to find more details.