### PR TITLE
*bug fix* wrong overload invocation of overloaded functions

### DIFF
--- a/lib/class-factory.js
+++ b/lib/class-factory.js
@@ -1386,40 +1386,38 @@ dispatcherPrototype = Object.create(Function.prototype, {
   invoke: {
     value (receiver, args) {
       const overloads = this._o;
-
-      const isInstance = receiver.$h !== null;
-      
-      const MethodsThatCanBeInvoked=[];
+      const isInstance = receiver.$h !== null; 
+      const methodsThatCanBeInvoked=[];
 
       for (let i = 0; i !== overloads.length; i++) {
         const method = overloads[i];
 
         if (method.canInvokeWith(args)) {
-          if (MethodsThatCanBeInvoked.length > 0) {
+          if (methodsThatCanBeInvoked.length > 0) {
             throwIfDispatcherAmbiguous(this);
           }
           
-          MethodsThatCanBeInvoked.push(method);
+          methodsThatCanBeInvoked.push(method);
         }  
       }
       
-      if (MethodsThatCanBeInvoked.length === 0){
+      if (methodsThatCanBeInvoked.length === 0) {
         throwOverloadError(this.methodName, this.overloads, 'argument types do not match any of:');
       }
       
-      const method = MethodsThatCanBeInvoked[0];
+      const method = methodsThatCanBeInvoked[0];
       
       if (method.type === INSTANCE_METHOD && !isInstance) {
-          const name = this.methodName;
+        const name = this.methodName;
 
-          if (name === 'toString') {
-            return `<class: ${receiver.$n}>`;
-          }
+        if (name === 'toString') {
+          return `<class: ${receiver.$n}>`;
+        }
 
-          throw new Error(name + ': cannot call instance method without an instance');
-       }
+        throw new Error(name + ': cannot call instance method without an instance');
+      }
 
-       return method.apply(receiver, args);
+      return method.apply(receiver, args);
     }
   }
 });

--- a/lib/class-factory.js
+++ b/lib/class-factory.js
@@ -1386,27 +1386,15 @@ dispatcherPrototype = Object.create(Function.prototype, {
   invoke: {
     value (receiver, args) {
       const overloads = this._o;
-      const isInstance = receiver.$h !== null; 
-      const methodsThatCanBeInvoked=[];
-
-      for (let i = 0; i !== overloads.length; i++) {
-        const method = overloads[i];
-
-        if (method.canInvokeWith(args)) {
-          if (methodsThatCanBeInvoked.length > 0) {
-            throwIfDispatcherAmbiguous(this);
-          }
-          
-          methodsThatCanBeInvoked.push(method);
-        }  
-      }
-      
+      const methodsThatCanBeInvoked = overloads.filter(method => method.canInvokeWith(args));
       if (methodsThatCanBeInvoked.length === 0) {
         throwOverloadError(this.methodName, this.overloads, 'argument types do not match any of:');
+      } else if (methodsThatCanBeInvoked.length > 1) {
+        throwIfDispatcherAmbiguous(this);
       }
-      
       const method = methodsThatCanBeInvoked[0];
-      
+
+      const isInstance = receiver.$h !== null;
       if (method.type === INSTANCE_METHOD && !isInstance) {
         const name = this.methodName;
 

--- a/lib/class-factory.js
+++ b/lib/class-factory.js
@@ -1388,15 +1388,28 @@ dispatcherPrototype = Object.create(Function.prototype, {
       const overloads = this._o;
 
       const isInstance = receiver.$h !== null;
+      
+      const MethodsThatCanBeInvoked=[];
 
       for (let i = 0; i !== overloads.length; i++) {
         const method = overloads[i];
 
-        if (!method.canInvokeWith(args)) {
-          continue;
-        }
-
-        if (method.type === INSTANCE_METHOD && !isInstance) {
+        if (method.canInvokeWith(args)) {
+          if (MethodsThatCanBeInvoked.length > 0) {
+            throwIfDispatcherAmbiguous(this);
+          }
+          
+          MethodsThatCanBeInvoked.push(method);
+        }  
+      }
+      
+      if (MethodsThatCanBeInvoked.length === 0){
+        throwOverloadError(this.methodName, this.overloads, 'argument types do not match any of:');
+      }
+      
+      const method = MethodsThatCanBeInvoked[0];
+      
+      if (method.type === INSTANCE_METHOD && !isInstance) {
           const name = this.methodName;
 
           if (name === 'toString') {
@@ -1404,12 +1417,9 @@ dispatcherPrototype = Object.create(Function.prototype, {
           }
 
           throw new Error(name + ': cannot call instance method without an instance');
-        }
+       }
 
-        return method.apply(receiver, args);
-      }
-
-      throwOverloadError(this.methodName, this.overloads, 'argument types do not match any of:');
+       return method.apply(receiver, args);
     }
   }
 });


### PR DESCRIPTION
the function invocation mechanism was choosing the first compatible func according the the args and available overloads but there was a bug since some types that are available in java are unified into one type in JS for example JS number can be int double float or long hence choosing the first might cause a problem (in my case an android app crashes due to the incorrect overload). instead of the current mechanism i have implemented a mechanism that goes over all of the overloads and if there is more then one matching overload it invokes the method throwIfDispatcherAmbiguous(dispatcher) which will alert the user about the multiple a available overloads and ask his to choose which one to use.