### PR TITLE
Fix 'state transition' error in Android x86_64

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -3538,19 +3538,22 @@ function recompileExceptionClearForX86 (buffer, pc, exceptionClearImpl, nextFunc
             if (dstOffset === exceptionOffset && src.value.valueOf() === 0) {
               threadReg = dstValue.base;
 
+              writer.putPushReg('xcx');
               writer.putPushfx();
               writer.putPushax();
               writer.putMovRegReg('xbp', 'xsp');
               if (pointerSize === 4) {
                 writer.putAndRegU32('esp', 0xfffffff0);
               } else {
-                writer.putMovRegU64('rax', uint64('0xfffffffffffffff0'));
-                writer.putAndRegReg('rsp', 'rax');
+                const tmpReg = (threadReg === 'rax') ? 'rcx' : 'rax'; // The threadReg can be 'rax';
+                writer.putMovRegU64(tmpReg, uint64('0xfffffffffffffff0'));
+                writer.putAndRegReg('rsp', tmpReg);
               }
               writer.putCallAddressWithAlignedArguments(callback, [threadReg]);
               writer.putMovRegReg('xsp', 'xbp');
               writer.putPopax();
               writer.putPopfx();
+              writer.putPopReg('xcx');
 
               foundCore = true;
               keep = false;


### PR DESCRIPTION
Running frida-server in Android x86_64 emulators may trigger the following errors:
```
{"type":"error","description":"TypeError: n is not a function","stack":"TypeError: n is not a function\n    at CallbackContext.pt (frida/node_modules/frida-java-bridge/lib/android.js:552:1)\n    at NativeFunction.<anonymous> (<anonymous>)\n    at lt (frida/node_modules/frida-java-bridge/lib/android.js:543:1)\n    at frida/node_modules/frida-java-bridge/lib/class-model.js:112:1\n    at Function.build (frida/node_modules/frida-java-bridge/lib/class-model.js:7:1)\n    at I._make (frida/node_modules/frida-java-bridge/lib/class-factory.js:115:1)\n    at I.use (frida/node_modules/frida-java-bridge/lib/class-factory.js:63:1)\n    at frida/node_modules/frida-java-bridge/index.js:212:1\n    at c.perform (frida/node_modules/frida-java-bridge/lib/vm.js:12:1)\n    at y._performPendingVmOpsWhenReady (frida/node_modules/frida-java-bridge/index.js:211:1)","fileName":"frida/node_modules/frida-java-bridge/lib/android.js","lineNumber":552,"columnNumber":1}
{"type":"error","description":"Error: Unable to perform state transition; please file a bug","stack":"Error: Unable to perform state transition; please file a bug\n    at lt (frida/node_modules/frida-java-bridge/lib/android.js:543:1)\n    at frida/node_modules/frida-java-bridge/lib/class-model.js:112:1\n    at Function.build (frida/node_modules/frida-java-bridge/lib/class-model.js:7:1)\n    at I._make (frida/node_modules/frida-java-bridge/lib/class-factory.js:115:1)\n    at I.use (frida/node_modules/frida-java-bridge/lib/class-factory.js:63:1)\n    at frida/node_modules/frida-java-bridge/index.js:212:1\n    at c.perform (frida/node_modules/frida-java-bridge/lib/vm.js:12:1)\n    at y._performPendingVmOpsWhenReady (frida/node_modules/frida-java-bridge/index.js:211:1)\n    at y.perform (frida/node_modules/frida-java-bridge/index.js:192:1)\n    at /internal-agent.js:490:6","fileName":"frida/node_modules/frida-java-bridge/lib/android.js","lineNumber":543,"columnNumber":1}
```

There are some similar reported issues, like https://github.com/frida/frida/issues/1917 and  https://github.com/frida/frida/issues/1848. 

In `android.js:3550`, the thread information is stored in `threadReg`. In some X86_64 images, the `threadReg` can be `rax` or `rcx`. 

The `rax` register is assigned to `0xfffffffffffffff0` in `android.js:3547` before the callback function is called.  If the `threadReg` is `rax`, the thread information will be overwritten. Then in `android.js:1211`, function `onThreadStateTransitionComplete` will fail to find the saved function.

This commit will use `rcx` as the temporary register if the threadReg is `rax`.

BTW, would you mind adding an explicit license file. I saw the license information in the `package.json`, but there isn't an explict license file.  Thank you!