### PR TITLE
[Fix] workaround for ClassLinker offset on Android 11 & 12

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -81,7 +81,6 @@ const SOCK_STREAM = 1;
 
 const getArtRuntimeSpec = memoize(_getArtRuntimeSpec);
 const getArtInstrumentationSpec = memoize(_getArtInstrumentationSpec);
-const getArtClassLinkerSpec = memoize(_getArtClassLinkerSpec);
 const getArtMethodSpec = memoize(_getArtMethodSpec);
 const getArtThreadSpec = memoize(_getArtThreadSpec);
 const getArtManagedStackSpec = memoize(_getArtManagedStackSpec);
@@ -103,6 +102,7 @@ const nativeFunctionOptions = {
 const artThreadStateTransitions = {};
 
 let cachedApi = null;
+let cachedArtClassLinkerSpec = null;
 let MethodMangler = null;
 let artController = null;
 const inlineHooks = [];
@@ -448,7 +448,8 @@ function _getApi () {
 
     const artRuntime = temporaryApi.vm.add(pointerSize).readPointer();
     temporaryApi.artRuntime = artRuntime;
-    const runtimeOffset = getArtRuntimeSpec(temporaryApi).offset;
+    const runtimeSpec = getArtRuntimeSpec(temporaryApi);
+    const runtimeOffset = runtimeSpec.offset;
     const instrumentationOffset = runtimeOffset.instrumentation;
     temporaryApi.artInstrumentation = (instrumentationOffset !== null) ? artRuntime.add(instrumentationOffset) : null;
 
@@ -463,7 +464,7 @@ function _getApi () {
      */
     const classLinker = artRuntime.add(runtimeOffset.classLinker).readPointer();
 
-    const classLinkerOffsets = getArtClassLinkerSpec(temporaryApi).offset;
+    const classLinkerOffsets = getArtClassLinkerSpec(artRuntime, runtimeSpec).offset;
     const quickResolutionTrampoline = classLinker.add(classLinkerOffsets.quickResolutionTrampoline).readPointer();
     const quickImtConflictTrampoline = classLinker.add(classLinkerOffsets.quickImtConflictTrampoline).readPointer();
     const quickGenericJniTrampoline = classLinker.add(classLinkerOffsets.quickGenericJniTrampoline).readPointer();
@@ -581,7 +582,7 @@ function getArtVMSpec (api) {
   };
 }
 
-function _getArtRuntimeSpec (api, testRClassIndex) {
+function _getArtRuntimeSpec (api) {
   /*
    * class Runtime {
    * ...
@@ -606,78 +607,64 @@ function _getArtRuntimeSpec (api, testRClassIndex) {
    * }
    */
 
-  const apiLevel = getAndroidApiLevel();
-
-  let rClassLinkerIndex = 3;
-  if (testRClassIndex === undefined && apiLevel < 33 && (apiLevel >= 30 || getAndroidCodename() === 'R')) {
-    try {
-      getArtClassLinkerSpec(api, 3);
-      rClassLinkerIndex = 3;
-    } catch (e) {
-      if (e.message === 'Unable to determine ClassLinker field offsets') {
-        try {
-          getArtClassLinkerSpec(api, 4);
-          rClassLinkerIndex = 4;
-        } catch (e) {
-          if (e.message === 'Unable to determine ClassLinker field offsets') {
-            throw new Error('Unable to determine ClassLinker field offsets (index 3 & 4 tried)');
-          }
-        }
-      }
-    }
-  }
-  if (testRClassIndex !== undefined) {
-    rClassLinkerIndex = testRClassIndex;
-  }
-
   const vm = api.vm;
   const runtime = api.artRuntime;
 
   const startOffset = (pointerSize === 4) ? 200 : 384;
   const endOffset = startOffset + (100 * pointerSize);
 
+  const apiLevel = getAndroidApiLevel();
+  const codename = getAndroidCodename();
+
   let spec = null;
 
   for (let offset = startOffset; offset !== endOffset; offset += pointerSize) {
     const value = runtime.add(offset).readPointer();
     if (value.equals(vm)) {
-      let classLinkerOffset = null;
+      let classLinkerOffsets;
       let jniIdManagerOffset = null;
-      if (apiLevel >= 33 || getAndroidCodename() === 'Tiramisu') {
-        classLinkerOffset = offset - (4 * pointerSize);
+      if (apiLevel >= 33 || codename === 'Tiramisu') {
+        classLinkerOffsets = [offset - (4 * pointerSize)];
         jniIdManagerOffset = offset - pointerSize;
-      } else if (apiLevel >= 30 || getAndroidCodename() === 'R') {
-        classLinkerOffset = offset - (rClassLinkerIndex * pointerSize);
+      } else if (apiLevel >= 30 || codename === 'R') {
+        classLinkerOffsets = [offset - (3 * pointerSize), offset - (4 * pointerSize)];
         jniIdManagerOffset = offset - pointerSize;
       } else if (apiLevel >= 29) {
-        classLinkerOffset = offset - (2 * pointerSize);
+        classLinkerOffsets = [offset - (2 * pointerSize)];
       } else if (apiLevel >= 27) {
-        classLinkerOffset = offset - STD_STRING_SIZE - (3 * pointerSize);
+        classLinkerOffsets = [offset - STD_STRING_SIZE - (3 * pointerSize)];
       } else {
-        classLinkerOffset = offset - STD_STRING_SIZE - (2 * pointerSize);
+        classLinkerOffsets = [offset - STD_STRING_SIZE - (2 * pointerSize)];
       }
 
-      const internTableOffset = classLinkerOffset - pointerSize;
-      const threadListOffset = internTableOffset - pointerSize;
+      for (const classLinkerOffset of classLinkerOffsets) {
+        const internTableOffset = classLinkerOffset - pointerSize;
+        const threadListOffset = internTableOffset - pointerSize;
 
-      let heapOffset;
-      if (apiLevel >= 24) {
-        heapOffset = threadListOffset - (8 * pointerSize);
-      } else if (apiLevel >= 23) {
-        heapOffset = threadListOffset - (7 * pointerSize);
-      } else {
-        heapOffset = threadListOffset - (4 * pointerSize);
-      }
-
-      spec = {
-        offset: {
-          heap: heapOffset,
-          threadList: threadListOffset,
-          internTable: internTableOffset,
-          classLinker: classLinkerOffset,
-          jniIdManager: jniIdManagerOffset
+        let heapOffset;
+        if (apiLevel >= 24) {
+          heapOffset = threadListOffset - (8 * pointerSize);
+        } else if (apiLevel >= 23) {
+          heapOffset = threadListOffset - (7 * pointerSize);
+        } else {
+          heapOffset = threadListOffset - (4 * pointerSize);
         }
-      };
+
+        const candidate = {
+          offset: {
+            heap: heapOffset,
+            threadList: threadListOffset,
+            internTable: internTableOffset,
+            classLinker: classLinkerOffset,
+            jniIdManager: jniIdManagerOffset
+          }
+        };
+        if (tryGetArtClassLinkerSpec(runtime, candidate) !== null) {
+          spec = candidate;
+          break;
+        }
+      }
+
       break;
     }
   }
@@ -855,7 +842,19 @@ function _getArtInstrumentationSpec () {
   };
 }
 
-function _getArtClassLinkerSpec (api, testRClassIndex) {
+function getArtClassLinkerSpec (runtime, runtimeSpec) {
+  const spec = tryGetArtClassLinkerSpec(runtime, runtimeSpec);
+  if (spec === null) {
+    throw new Error('Unable to determine ClassLinker field offsets');
+  }
+  return spec;
+}
+
+function tryGetArtClassLinkerSpec (runtime, runtimeSpec) {
+  if (cachedArtClassLinkerSpec !== null) {
+    return cachedArtClassLinkerSpec;
+  }
+
   /*
    * On Android 5.x:
    *
@@ -884,11 +883,9 @@ function _getArtClassLinkerSpec (api, testRClassIndex) {
    * }
    */
 
-  const runtime = api.artRuntime;
-  const runtimeSpec = getArtRuntimeSpec(api, testRClassIndex);
-
-  const classLinker = runtime.add(runtimeSpec.offset.classLinker).readPointer();
-  const internTable = runtime.add(runtimeSpec.offset.internTable).readPointer();
+  const { classLinker: classLinkerOffset, internTable: internTableOffset } = runtimeSpec.offset;
+  const classLinker = runtime.add(classLinkerOffset).readPointer();
+  const internTable = runtime.add(internTableOffset).readPointer();
 
   const startOffset = (pointerSize === 4) ? 100 : 200;
   const endOffset = startOffset + (100 * pointerSize);
@@ -933,8 +930,8 @@ function _getArtClassLinkerSpec (api, testRClassIndex) {
     }
   }
 
-  if (spec === null) {
-    throw new Error('Unable to determine ClassLinker field offsets');
+  if (spec !== null) {
+    cachedArtClassLinkerSpec = spec;
   }
 
   return spec;

--- a/lib/android.js
+++ b/lib/android.js
@@ -581,7 +581,7 @@ function getArtVMSpec (api) {
   };
 }
 
-function _getArtRuntimeSpec (api) {
+function _getArtRuntimeSpec (api, testRClassIndex) {
   /*
    * class Runtime {
    * ...
@@ -605,14 +605,36 @@ function _getArtRuntimeSpec (api) {
    * ...
    * }
    */
+  
+  const apiLevel = getAndroidApiLevel();
+
+  var RClassLinkerIndex = 3;
+  if(!testRClassIndex && (apiLevel >= 30 || getAndroidCodename() === 'R')){
+    try{
+      getArtClassLinkerSpec(api, 3);
+      RClassLinkerIndex = 3;
+    } catch {
+      if(e.message === 'Unable to determine ClassLinker field offsets'){
+        try{
+          getArtClassLinkerSpec(api, 4);
+          RClassLinkerIndex = 4;
+        } catch {
+          if(e.message === 'Unable to determine ClassLinker field offsets'){
+              throw new Error('Unable to determine ClassLinker field offsets (index 3 & 4 tried)');
+          }
+        }
+      }
+    }
+  }
+  if(testRClassIndex)
+    RClassLinkerIndex = testRClassIndex;
+  
 
   const vm = api.vm;
   const runtime = api.artRuntime;
 
   const startOffset = (pointerSize === 4) ? 200 : 384;
   const endOffset = startOffset + (100 * pointerSize);
-
-  const apiLevel = getAndroidApiLevel();
 
   let spec = null;
 
@@ -625,7 +647,7 @@ function _getArtRuntimeSpec (api) {
         classLinkerOffset = offset - (4 * pointerSize);
         jniIdManagerOffset = offset - pointerSize;
       } else if (apiLevel >= 30 || getAndroidCodename() === 'R') {
-        classLinkerOffset = offset - (3 * pointerSize);
+        classLinkerOffset = offset - (RClassLinkerIndex * pointerSize);
         jniIdManagerOffset = offset - pointerSize;
       } else if (apiLevel >= 29) {
         classLinkerOffset = offset - (2 * pointerSize);
@@ -833,7 +855,7 @@ function _getArtInstrumentationSpec () {
   };
 }
 
-function _getArtClassLinkerSpec (api) {
+function _getArtClassLinkerSpec (api, testRClassIndex) {
   /*
    * On Android 5.x:
    *
@@ -863,7 +885,7 @@ function _getArtClassLinkerSpec (api) {
    */
 
   const runtime = api.artRuntime;
-  const runtimeSpec = getArtRuntimeSpec(api);
+  const runtimeSpec = getArtRuntimeSpec(api, testRClassIndex);
 
   const classLinker = runtime.add(runtimeSpec.offset.classLinker).readPointer();
   const internTable = runtime.add(runtimeSpec.offset.internTable).readPointer();

--- a/lib/android.js
+++ b/lib/android.js
@@ -609,7 +609,7 @@ function _getArtRuntimeSpec (api, testRClassIndex) {
   const apiLevel = getAndroidApiLevel();
 
   let rClassLinkerIndex = 3;
-  if (testRClassIndex === undefined && (apiLevel >= 30 || getAndroidCodename() === 'R')) {
+  if (testRClassIndex === undefined && apiLevel < 33 && (apiLevel >= 30 || getAndroidCodename() === 'R')) {
     try {
       getArtClassLinkerSpec(api, 3);
       rClassLinkerIndex = 3;

--- a/lib/android.js
+++ b/lib/android.js
@@ -605,30 +605,30 @@ function _getArtRuntimeSpec (api, testRClassIndex) {
    * ...
    * }
    */
-  
+
   const apiLevel = getAndroidApiLevel();
 
-  var RClassLinkerIndex = 3;
-  if(!testRClassIndex && (apiLevel >= 30 || getAndroidCodename() === 'R')){
-    try{
+  let rClassLinkerIndex = 3;
+  if (testRClassIndex === undefined && (apiLevel >= 30 || getAndroidCodename() === 'R')) {
+    try {
       getArtClassLinkerSpec(api, 3);
-      RClassLinkerIndex = 3;
-    } catch {
-      if(e.message === 'Unable to determine ClassLinker field offsets'){
-        try{
+      rClassLinkerIndex = 3;
+    } catch (e) {
+      if (e.message === 'Unable to determine ClassLinker field offsets') {
+        try {
           getArtClassLinkerSpec(api, 4);
-          RClassLinkerIndex = 4;
-        } catch {
-          if(e.message === 'Unable to determine ClassLinker field offsets'){
-              throw new Error('Unable to determine ClassLinker field offsets (index 3 & 4 tried)');
+          rClassLinkerIndex = 4;
+        } catch (e) {
+          if (e.message === 'Unable to determine ClassLinker field offsets') {
+            throw new Error('Unable to determine ClassLinker field offsets (index 3 & 4 tried)');
           }
         }
       }
     }
   }
-  if(testRClassIndex)
-    RClassLinkerIndex = testRClassIndex;
-  
+  if (testRClassIndex !== undefined) {
+    rClassLinkerIndex = testRClassIndex;
+  }
 
   const vm = api.vm;
   const runtime = api.artRuntime;
@@ -647,7 +647,7 @@ function _getArtRuntimeSpec (api, testRClassIndex) {
         classLinkerOffset = offset - (4 * pointerSize);
         jniIdManagerOffset = offset - pointerSize;
       } else if (apiLevel >= 30 || getAndroidCodename() === 'R') {
-        classLinkerOffset = offset - (RClassLinkerIndex * pointerSize);
+        classLinkerOffset = offset - (rClassLinkerIndex * pointerSize);
         jniIdManagerOffset = offset - pointerSize;
       } else if (apiLevel >= 29) {
         classLinkerOffset = offset - (2 * pointerSize);


### PR DESCRIPTION
Some devices are getting "Unable to determine ClassLinker field offsets".
https://github.com/frida/frida/issues/2176

This could be related to ROM, or apparently "Google Play System Update".
Changing `classLinkerOffset = offset - (3 * pointerSize);` to `classLinkerOffset = offset - (4 * pointerSize);` fixed this issue for these devices, however so far it's unclear what is causing this change.

This workaround tries with `3` first, and if it fails, it tries `4`. I had to disable memoize because for some reason it wouldn't run with new arguments. The code isn't perfect, but it works, of course improvements by the community are most welcome.

Tested the same `frida-server` on multiple devices with and without the issue, and it seems to be resolved with this patch.

If allowed, I'd like to publish binaries for android-arm until an official release is out.