### PR TITLE
i#306: Fix hooking art_quick_resolution_trampoline

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -483,7 +483,8 @@ function _getApi () {
 
     temporaryApi.artQuickGenericJniTrampoline = getArtQuickEntrypointFromTrampoline(quickGenericJniTrampoline, vm);
     temporaryApi.artQuickToInterpreterBridge = getArtQuickEntrypointFromTrampoline(quickToInterpreterBridgeTrampoline, vm);
-
+    temporaryApi.artQuickResolutionTrampoline = getArtQuickEntrypointFromTrampoline(quickResolutionTrampoline, vm);
+    
     if (temporaryApi['art::JavaVMExt::AddGlobalRef'] === undefined) {
       temporaryApi['art::JavaVMExt::AddGlobalRef'] = makeAddGlobalRefFallbackForAndroid5(temporaryApi);
     }
@@ -1825,7 +1826,8 @@ function instrumentArtQuickEntrypoints (vm) {
   // Entrypoints that dispatch method invocation from the quick ABI.
   const quickEntrypoints = [
     api.artQuickGenericJniTrampoline,
-    api.artQuickToInterpreterBridge
+    api.artQuickToInterpreterBridge,
+    api.artQuickResolutionTrampoline
   ];
 
   quickEntrypoints.forEach(entrypoint => {


### PR DESCRIPTION
Fixes issue when using --enable-optimizations on newer ARTs where quick entrypoints can be art_quick_resolution_trampoline