### PR TITLE
Add support for instantiating classes that do not have a constructor

### DIFF
--- a/lib/class-factory.js
+++ b/lib/class-factory.js
@@ -1332,7 +1332,7 @@ function makeConstructor (classHandle, classWrapper, env) {
   try {
     const n = env.getArrayLength(constructors);
 
-    if (n > 0) {
+    if (n !== 0) {
       for (let i = 0; i !== n; i++) {
         let methodId, types;
         const constructor = env.getObjectArrayElement(constructors, i);
@@ -1355,9 +1355,8 @@ function makeConstructor (classHandle, classWrapper, env) {
       }
     } else {
       const isInterface = invokeUInt8MethodNoArgs(env.handle, classHandle, Class.isInterface);
-
       if (isInterface) {
-        throw new Error('Can not instantiate an interface');
+        throw new Error('cannot instantiate an interface');
       }
 
       const defaultClass = env.javaLangObject();

--- a/lib/class-factory.js
+++ b/lib/class-factory.js
@@ -1318,37 +1318,53 @@ function makeSuperHandleGetter (classWrapper) {
 function makeConstructor (classHandle, classWrapper, env) {
   const { $n: className, $f: factory } = classWrapper;
   const methodName = basename(className);
+  const Class = env.javaLangClass();
   const Constructor = env.javaLangReflectConstructor();
   const invokeObjectMethodNoArgs = env.vaMethod('pointer', []);
+  const invokeUInt8MethodNoArgs = env.vaMethod('uint8', []);
 
   const jsCtorMethods = [];
   const jsInitMethods = [];
   const jsRetType = factory._getType(className, false);
   const jsVoidType = factory._getType('void', false);
 
-  const constructors = invokeObjectMethodNoArgs(env.handle, classHandle, env.javaLangClass().getDeclaredConstructors);
+  const constructors = invokeObjectMethodNoArgs(env.handle, classHandle, Class.getDeclaredConstructors);
   try {
     const n = env.getArrayLength(constructors);
 
-    for (let i = 0; i !== n; i++) {
-      let methodId, types;
-      const constructor = env.getObjectArrayElement(constructors, i);
-      try {
-        methodId = env.fromReflectedMethod(constructor);
-        types = invokeObjectMethodNoArgs(env.handle, constructor, Constructor.getGenericParameterTypes);
-      } finally {
-        env.deleteLocalRef(constructor);
+    if (n > 0) {
+      for (let i = 0; i !== n; i++) {
+        let methodId, types;
+        const constructor = env.getObjectArrayElement(constructors, i);
+        try {
+          methodId = env.fromReflectedMethod(constructor);
+          types = invokeObjectMethodNoArgs(env.handle, constructor, Constructor.getGenericParameterTypes);
+        } finally {
+          env.deleteLocalRef(constructor);
+        }
+
+        let jsArgTypes;
+        try {
+          jsArgTypes = readTypeNames(env, types).map(name => factory._getType(name));
+        } finally {
+          env.deleteLocalRef(types);
+        }
+
+        jsCtorMethods.push(makeMethod(methodName, classWrapper, CONSTRUCTOR_METHOD, methodId, jsRetType, jsArgTypes, env));
+        jsInitMethods.push(makeMethod(methodName, classWrapper, INSTANCE_METHOD, methodId, jsVoidType, jsArgTypes, env));
+      }
+    } else {
+      const isInterface = invokeUInt8MethodNoArgs(env.handle, classHandle, Class.isInterface);
+
+      if (isInterface) {
+        throw new Error('Can not instantiate an interface');
       }
 
-      let jsArgTypes;
-      try {
-        jsArgTypes = readTypeNames(env, types).map(name => factory._getType(name));
-      } finally {
-        env.deleteLocalRef(types);
-      }
+      const defaultClass = env.javaLangObject();
+      const defaultConstructor = env.getMethodId(defaultClass, '<init>', '()V');
 
-      jsCtorMethods.push(makeMethod(methodName, classWrapper, CONSTRUCTOR_METHOD, methodId, jsRetType, jsArgTypes, env));
-      jsInitMethods.push(makeMethod(methodName, classWrapper, INSTANCE_METHOD, methodId, jsVoidType, jsArgTypes, env));
+      jsCtorMethods.push(makeMethod(methodName, classWrapper, CONSTRUCTOR_METHOD, defaultConstructor, jsRetType, [], env));
+      jsInitMethods.push(makeMethod(methodName, classWrapper, INSTANCE_METHOD, defaultConstructor, jsVoidType, [], env));
     }
   } finally {
     env.deleteLocalRef(constructors);

--- a/lib/env.js
+++ b/lib/env.js
@@ -667,6 +667,7 @@ Env.prototype.javaLangClass = function () {
         getDeclaredFields: get('getDeclaredFields', '()[Ljava/lang/reflect/Field;'),
         isArray: get('isArray', '()Z'),
         isPrimitive: get('isPrimitive', '()Z'),
+        isInterface: get('isInterface', '()Z'),
         getComponentType: get('getComponentType', '()Ljava/lang/Class;')
       };
     } finally {
@@ -683,6 +684,7 @@ Env.prototype.javaLangObject = function () {
     try {
       const get = this.getMethodId.bind(this, handle);
       javaLangObject = {
+        handle: register(this.newGlobalRef(handle)),
         toString: get('toString', '()Ljava/lang/String;'),
         getClass: get('getClass', '()Ljava/lang/Class;')
       };


### PR DESCRIPTION
With this PR you can instantiate java classes that do not have a constructor, by using the `java/lang/Object->init()` method.
I'm not sure if we need to handle more edge cases like the `isInterface` check.