### PR TITLE
fix(android): set DexFile to read-only in Java.registerClass()

### DIFF
--- a/lib/class-factory.js
+++ b/lib/class-factory.js
@@ -2193,6 +2193,7 @@ class DexFile {
     const file = new File(filePath, 'w');
     file.write(buffer.buffer);
     file.close();
+    setReadOnlyDex(filePath, factory);
 
     return new DexFile(filePath, fileValue, factory);
   }
@@ -2249,6 +2250,12 @@ function createTemporaryDex (factory) {
   cacheDirValue.mkdirs();
 
   return JFile.createTempFile(tempFileNaming.prefix, tempFileNaming.suffix + '.dex', cacheDirValue);
+}
+
+function setReadOnlyDex (filePath, factory) {
+  const JFile = factory.use('java.io.File');
+  const file = JFile.$new(filePath);
+  file.setWritable(false, false);
 }
 
 function getFactoryCache () {


### PR DESCRIPTION
As of Android 14, apps with targetSdk >= 34 are not allowed to have writable permissions on dynamically loaded Dex files.

https://developer.android.com/about/versions/14/behavior-changes-14#safer-dynamic-code-loading

Attempting to call `Java.registerClass()` with such apps results in an exception being thrown:

```
java.lang.SecurityException: Writable dex file '/data/data/my.ebin.app/frida4706282976511766825.dex' is not allowed.
```

This removes writable permissions from the temporary DexFile created by `Java.registerClass()` after writing to it and before it gets loaded.