### PR TITLE
fix: sort field items according to dex_file_verifier.cc

### DIFF
--- a/lib/mkdex.js
+++ b/lib/mkdex.js
@@ -655,7 +655,7 @@ function computeModel (classes) {
       stringToIndex[fieldName]
     ];
   });
-  fieldItems.sort(compareFieldItems)
+  fieldItems.sort(compareFieldItems);
 
   const methodItems = methods.map(method => {
     const [klass, protoId, name, annotationsId] = method;
@@ -745,7 +745,7 @@ function computeModel (classes) {
     const instanceFields = fieldItems.reduce((result, field, index) => {
       const [holder] = field;
       if (holder === classIndex) {
-        result.push([index>0?1:0, kAccPublic]);
+        result.push([index > 0 ? 1 : 0, kAccPublic]);
       }
       return result;
     }, []);

--- a/lib/mkdex.js
+++ b/lib/mkdex.js
@@ -655,6 +655,7 @@ function computeModel (classes) {
       stringToIndex[fieldName]
     ];
   });
+  fieldItems.sort(compareFieldItems)
 
   const methodItems = methods.map(method => {
     const [klass, protoId, name, annotationsId] = method;
@@ -744,7 +745,7 @@ function computeModel (classes) {
     const instanceFields = fieldItems.reduce((result, field, index) => {
       const [holder] = field;
       if (holder === classIndex) {
-        result.push([index, kAccPublic]);
+        result.push([index>0?1:0, kAccPublic]);
       }
       return result;
     }, []);
@@ -848,6 +849,20 @@ function compareProtoItems (a, b) {
   return 0;
 }
 
+function compareFieldItems (a, b) {
+  const [aClass, aType, aName] = a;
+  const [bClass, bType, bName] = b;
+
+  if (aClass !== bClass) {
+    return aClass - bClass;
+  }
+
+  if (aName !== bName) {
+    return aName - bName;
+  }
+
+  return aType - bType;
+}
 function compareMethodItems (a, b) {
   const [aClass, aProto, aName] = a;
   const [bClass, bProto, bName] = b;

--- a/lib/mkdex.js
+++ b/lib/mkdex.js
@@ -863,6 +863,7 @@ function compareFieldItems (a, b) {
 
   return aType - bType;
 }
+
 function compareMethodItems (a, b) {
   const [aClass, aProto, aName] = a;
   const [bClass, bProto, bName] = b;

--- a/test/re/frida/ClassCreationTest.java
+++ b/test/re/frida/ClassCreationTest.java
@@ -321,6 +321,7 @@ public class ClassCreationTest {
                 "  fields: {" +
                 "    lastInt: 'int'," +
                 "    lastStr: 'java.lang.String'," +
+                "    lastByteArr: '[B'," +
                 "  }," +
                 "  methods: {" +
                 "    format: [{" +


### PR DESCRIPTION
registerClass creates wrong dex file when there are more than 2 fields #296 

This commit fixes two errors:
- field_ids items are not sorted. 
- field_idx_diff wrongly calculated. (0,1,2,3) needs to be (0,1,1,1)

Since we create 1 dex file for each registerClass, we don't need to keep track of field_idx_diff. (okay to begin from 0)