### PR TITLE
handle CMC GC strategy

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -1890,6 +1890,11 @@ function ensureArtKnowsHowToHandleReplacementMethods (vm) {
 
   if (exportName !== null) {
     Interceptor.attach(Module.getExportByName('libart.so', exportName), artController.hooks.Gc.copyingPhase);
+
+    const collectorCMC = Module.findExportByName('libart.so', '_ZN3art2gc9collector11MarkCompact15CompactionPhaseEv');
+    if (collectorCMC !== null) {
+      Interceptor.attach(collectorCMC, artController.hooks.Gc.copyingPhase);
+    }
   }
 }
 

--- a/lib/android.js
+++ b/lib/android.js
@@ -591,8 +591,9 @@ function _getArtRuntimeSpec (api) {
    * gc::Heap* heap_;                <-- we need to find this
    * std::unique_ptr<ArenaPool> jit_arena_pool_;     <----- API level >= 24
    * std::unique_ptr<ArenaPool> arena_pool_;             __
-   * std::unique_ptr<ArenaPool> low_4gb_arena_pool_; <--|__ API level >= 23
+   * std::unique_ptr<ArenaPool> low_4gb_arena_pool_/linear_alloc_arena_pool_; <--|__ API level >= 23
    * std::unique_ptr<LinearAlloc> linear_alloc_;         \_
+   * std::atomic<LinearAlloc*> startup_linear_alloc_;<----- API level >= 34
    * size_t max_spins_before_thin_lock_inflation_;
    * MonitorList* monitor_list_;
    * MonitorPool* monitor_pool_;
@@ -644,7 +645,9 @@ function _getArtRuntimeSpec (api) {
         const threadListOffset = internTableOffset - pointerSize;
 
         let heapOffset;
-        if (apiLevel >= 24) {
+        if (apiLevel >= 34) {
+          heapOffset = threadListOffset - (9 * pointerSize);
+        } else if (apiLevel >= 24) {
           heapOffset = threadListOffset - (8 * pointerSize);
         } else if (apiLevel >= 23) {
           heapOffset = threadListOffset - (7 * pointerSize);


### PR DESCRIPTION
Fixes https://github.com/frida/frida-java-bridge/issues/323
It is related to this commit https://github.com/liuyufei/frida-java-bridge/commit/c52014e5ae1d864115a541265942bb330257c30b which was made to force an update of the ArtMethods containing the hooks after a GC. 

With the recent updates of Android/libart/Google Play System Updates on certain devices it has been enabled the CMC (MarkCompact collector) instead of CC (ConcurrentCopying).
 
 

