### PR TITLE
android: Handle correctly the CMC GC strategy

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -618,6 +618,7 @@ function _getArtRuntimeSpec (api) {
 
   const apiLevel = getAndroidApiLevel();
   const codename = getAndroidCodename();
+  const isApiLevel34OrApexEquivalent = Module.findExportByName('libart.so', '_ZN3art7AppInfo29GetPrimaryApkReferenceProfileEv') !== null;
 
   let spec = null;
 
@@ -645,7 +646,7 @@ function _getArtRuntimeSpec (api) {
         const threadListOffset = internTableOffset - pointerSize;
 
         let heapOffset;
-        if (apiLevel >= 34) {
+        if (isApiLevel34OrApexEquivalent) {
           heapOffset = threadListOffset - (9 * pointerSize);
         } else if (apiLevel >= 24) {
           heapOffset = threadListOffset - (8 * pointerSize);

--- a/lib/android.js
+++ b/lib/android.js
@@ -1808,6 +1808,9 @@ on_leave_gc_concurrent_copying_copying_phase (GumInvocationContext * ic)
       Gc: {
         copyingPhase: {
           onLeave: cm.on_leave_gc_concurrent_copying_copying_phase
+        },
+        runFlip: {
+          onEnter: cm.on_leave_gc_concurrent_copying_copying_phase
         }
       }
     }
@@ -1885,19 +1888,22 @@ function ensureArtKnowsHowToHandleReplacementMethods (vm) {
 
   const apiLevel = getAndroidApiLevel();
 
-  let exportName = null;
-  if (apiLevel > 28) {
-    exportName = '_ZN3art2gc9collector17ConcurrentCopying12CopyingPhaseEv';
-  } else if (apiLevel > 22) {
-    exportName = '_ZN3art2gc9collector17ConcurrentCopying12MarkingPhaseEv';
-  }
+  const mayUseCollector = (apiLevel > 28)
+    ? new NativeFunction(Module.getExportByName('libart.so', '_ZNK3art2gc4Heap15MayUseCollectorENS0_13CollectorTypeE'), 'bool', ['pointer', 'int'])
+    : () => false;
+  const kCollectorTypeCMC = 3;
 
-  if (exportName !== null) {
-    Interceptor.attach(Module.getExportByName('libart.so', exportName), artController.hooks.Gc.copyingPhase);
-
-    const collectorCMC = Module.findExportByName('libart.so', '_ZN3art2gc9collector11MarkCompact15CompactionPhaseEv');
-    if (collectorCMC !== null) {
-      Interceptor.attach(collectorCMC, artController.hooks.Gc.copyingPhase);
+  if (mayUseCollector(getApi().artHeap, kCollectorTypeCMC)) {
+    Interceptor.attach(Module.getExportByName('libart.so', '_ZN3art6Thread15RunFlipFunctionEPS0_b'), artController.hooks.Gc.runFlip);
+  } else {
+    let exportName = null;
+    if (apiLevel > 28) {
+      exportName = '_ZN3art2gc9collector17ConcurrentCopying12CopyingPhaseEv';
+    } else if (apiLevel > 22) {
+      exportName = '_ZN3art2gc9collector17ConcurrentCopying12MarkingPhaseEv';
+    }
+    if (exportName !== null) {
+      Interceptor.attach(Module.getExportByName('libart.so', exportName), artController.hooks.Gc.copyingPhase);
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/frida/frida-java-bridge/issues/323.

The fix in https://github.com/frida/frida-java-bridge/pull/325 had 2 problems:
- with the Google Play System Updates the base version of libart can differ from the Android version( i.e. Android 12 device with libart 34)
- the function we were hooking in the MarkCompact GC was not stable enough causing crashes after some time. [tombstone_01.txt](https://github.com/user-attachments/files/16249961/tombstone_01.txt)

The proposed solution to the first point is to check if an exported symbol introduced in libart 34 is present.

The solution for the second problem is to hook the onEnter of art::Thread::RunFlipFunction
- this function is called also during in the ConcurrentCopying GC and in my tests didn't cause troubles but to avoid compatibility problems with untested version I've reintroduced the check on the GC strategy;
- the downside of hooking art::Thread::RunFlipFunction is that it is called several times (tens) every run of the GC but anyother place I've tried was causing crashes.