### PR TITLE
android: Fix art::Thread::DecodeJObject for Android>=15

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -3860,7 +3860,7 @@ function makeDecodeGlobalFallback (api) {
    */
   const decode = api['art::Thread::DecodeJObject'];
   if (decode === undefined) {
-    throw new Error('art::Thread::DecodeJObject is not available. Please file a bug.');
+    throw new Error('art::Thread::DecodeJObject is not available; please file a bug');
   }
 
   return function (vm, thread, ref) {

--- a/lib/android.js
+++ b/lib/android.js
@@ -187,7 +187,11 @@ function _getApi () {
           },
           // Android >= 6
           _ZN3art9JavaVMExt12DecodeGlobalEPNS_6ThreadEPv: ['art::JavaVMExt::DecodeGlobal', 'pointer', ['pointer', 'pointer', 'pointer']],
-          // Android < 6: makeDecodeGlobalFallbackForAndroid5() fallback uses:
+
+          // makeDecodeGlobalFallback() uses:
+          // Android >= 15
+          _ZNK3art6Thread19DecodeGlobalJObjectEP8_jobject: ['art::Thread::DecodeJObject', 'pointer', ['pointer', 'pointer']],
+          // Android < 6
           _ZNK3art6Thread13DecodeJObjectEP8_jobject: ['art::Thread::DecodeJObject', 'pointer', ['pointer', 'pointer']],
 
           // Android >= 6
@@ -314,6 +318,7 @@ function _getApi () {
           '_ZN3art9JavaVMExt12AddGlobalRefEPNS_6ThreadEPNS_6mirror6ObjectE',
           '_ZN3art9JavaVMExt12DecodeGlobalEPv',
           '_ZN3art9JavaVMExt12DecodeGlobalEPNS_6ThreadEPv',
+          '_ZNK3art6Thread19DecodeGlobalJObjectEP8_jobject',
           '_ZNK3art6Thread13DecodeJObjectEP8_jobject',
           '_ZN3art10ThreadList10SuspendAllEPKcb',
           '_ZN3art10ThreadList10SuspendAllEv',
@@ -489,7 +494,7 @@ function _getApi () {
       temporaryApi['art::JavaVMExt::AddGlobalRef'] = makeAddGlobalRefFallbackForAndroid5(temporaryApi);
     }
     if (temporaryApi['art::JavaVMExt::DecodeGlobal'] === undefined) {
-      temporaryApi['art::JavaVMExt::DecodeGlobal'] = makeDecodeGlobalFallbackForAndroid5(temporaryApi);
+      temporaryApi['art::JavaVMExt::DecodeGlobal'] = makeDecodeGlobalFallback(temporaryApi);
     }
     if (temporaryApi['art::ArtMethod::PrettyMethod'] === undefined) {
       temporaryApi['art::ArtMethod::PrettyMethod'] = temporaryApi['art::ArtMethod::PrettyMethodNullSafe'];
@@ -3848,8 +3853,15 @@ function makeAddGlobalRefFallbackForAndroid5 (api) {
   };
 }
 
-function makeDecodeGlobalFallbackForAndroid5 (api) {
+function makeDecodeGlobalFallback (api) {
+  /*
+   * Fallback for art::JavaVMExt::DecodeGlobal, which is
+   * unavailable in Android versions <= 5 and >= 15.
+   */
   const decode = api['art::Thread::DecodeJObject'];
+  if (decode === undefined) {
+    throw new Error('art::Thread::DecodeJObject is not available. Please file a bug.');
+  }
 
   return function (vm, thread, ref) {
     return decode(thread, ref);


### PR DESCRIPTION
In Android 15, `DecodeGlobal` is not available as `_ZN3art9JavaVMExt12DecodeGlobalEPv` is no longer exported by the ART runtime. Additionally, the fallback option `DecodeJObject` is ineffective because it's signature changed from `_ZNK3art6Thread13DecodeJObjectEP8_jobject` to `_ZNK3art6Thread19DecodeGlobalJObjectEP8_jobject` in some version between 6 and 14, throwing an unexpected error during `perform()` or `performNow()` calls.

This PR resolves the issue by making the Java API compatible with Android 15 and ensuring `DecodeJObject` is available if the fallback is needed.

Fixes #317