### PR TITLE
android: fix bug where MayUseCollector is not available on some custom rom

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -1894,21 +1894,27 @@ function ensureArtKnowsHowToHandleReplacementMethods (vm) {
   const apiLevel = getAndroidApiLevel();
 
   const mayUseCollector = (apiLevel > 28)
-    ? new NativeFunction(Module.getExportByName('libart.so', '_ZNK3art2gc4Heap15MayUseCollectorENS0_13CollectorTypeE'), 'bool', ['pointer', 'int'])
+    ? (type) => {
+        const impl = Module.findExportByName('libart.so', '_ZNK3art2gc4Heap15MayUseCollectorENS0_13CollectorTypeE');
+        if (impl === null) {
+          return false;
+        }
+        return new NativeFunction(impl, 'bool', ['pointer', 'int'])(getApi().artHeap, type);
+      }
     : () => false;
   const kCollectorTypeCMC = 3;
 
-  if (mayUseCollector(getApi().artHeap, kCollectorTypeCMC)) {
+  if (mayUseCollector(kCollectorTypeCMC)) {
     Interceptor.attach(Module.getExportByName('libart.so', '_ZN3art6Thread15RunFlipFunctionEPS0_b'), artController.hooks.Gc.runFlip);
   } else {
-    let exportName = null;
+    let copyingPhase = null;
     if (apiLevel > 28) {
-      exportName = '_ZN3art2gc9collector17ConcurrentCopying12CopyingPhaseEv';
+      copyingPhase = Module.findExportByName('libart.so', '_ZN3art2gc9collector17ConcurrentCopying12CopyingPhaseEv');
     } else if (apiLevel > 22) {
-      exportName = '_ZN3art2gc9collector17ConcurrentCopying12MarkingPhaseEv';
+      copyingPhase = Module.findExportByName('libart.so', '_ZN3art2gc9collector17ConcurrentCopying12MarkingPhaseEv');
     }
-    if (exportName !== null) {
-      Interceptor.attach(Module.getExportByName('libart.so', exportName), artController.hooks.Gc.copyingPhase);
+    if (copyingPhase !== null) {
+      Interceptor.attach(copyingPhase, artController.hooks.Gc.copyingPhase);
     }
   }
 }


### PR DESCRIPTION
fix `Error: libart.so: unable to find export '_ZNK3art2gc4Heap15MayUseCollectorENS0_13CollectorTypeE`
eg: https://github.com/frida/frida/issues/2925
original change: https://github.com/frida/frida-java-bridge/pull/326