### PR TITLE
android: alternative offset to ExceptionClear in libart (https://github.com/frida/frida/issues/2958)(https://github.com/frida/frida-java-bridge/issues/336)

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -503,7 +503,7 @@ function _getApi () {
     if (temporaryApi['art::interpreter::GetNterpEntryPoint'] !== undefined) {
       temporaryApi.artNterpEntryPoint = temporaryApi['art::interpreter::GetNterpEntryPoint']();
     } else {
-      if (Process.arch === 'arm64') {
+      if (Process.arch === 'arm64' && getAndroidApiLevel() >= 30) {
         temporaryApi.artNterpEntryPoint = findExecuteNterpImpl();
       }
     }
@@ -631,7 +631,7 @@ function tryGetEnvJvmti (vm, runtime) {
     let ensurePluginLoaded;
     if (Module.findExportByName('libart.so', '_ZN3art7Runtime18EnsurePluginLoadedEPKcPNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEE') === null) {
       // on some devices calling the ensurePluginLoaded make the app really slow so for is commented
-      if (env !== null & Process.arch === 'arm64') {
+      if (env !== null && Process.arch === 'arm64') {
         const candidates = findEnsurePlugIn();
         ensurePluginLoaded = new NativeFunction(candidates[0],
           'bool',
@@ -1989,7 +1989,7 @@ function instrumentArtMethodInvocationFromInterpreter () {
     docallFound = false;
     Interceptor.attach(exp.address, artController.hooks.Interpreter.doCall);
   }
-  if (docallFound & Process.arch === 'arm64') {
+  if (docallFound && Process.arch === 'arm64') {
     const doCallsCandidates = findDoCalls();
     for (const address of doCallsCandidates) {
       Interceptor.attach(address, artController.hooks.Interpreter.doCall);
@@ -3536,7 +3536,7 @@ class ArtMethodMangler {
 
     // Replace Nterp quick entrypoints with art_quick_to_interpreter_bridge to force stepping out
     // of ART's next-generation interpreter and use the quick stub instead.
-    if (artNterpEntryPoint !== undefined && quickCode.equals(artNterpEntryPoint)) {
+    if (artNterpEntryPoint !== undefined && artNterpEntryPoint !== 0 && quickCode.equals(artNterpEntryPoint)) {
       patchArtMethod(hookedMethodId, {
         quickCode: api.artQuickToInterpreterBridge
       }, vm);


### PR DESCRIPTION
In the latest libart versions (35xxxxxxx) the offset in the vtable of venv for ExceptionClear is not valid anymore. 
I added a check through an heuristic to detect if the found function is the correct one or if the new offset is needed.

The commit is only for arm64, a fix for other architectures may be needed.

Tested on libart:

350820380
350820960
350820860