### PR TITLE
registerClass static method support

### DIFF
--- a/lib/class-factory.js
+++ b/lib/class-factory.js
@@ -16,6 +16,8 @@ const {
   makeJniObjectTypeName
 } = require('./types');
 
+const kAccStatic = 0x0008;
+
 const CONSTRUCTOR_METHOD = 1;
 const STATIC_METHOD = 2;
 const INSTANCE_METHOD = 3;
@@ -450,6 +452,9 @@ class ClassFactory {
             impl = methodValue;
           }
         } else {
+          if (methodValue.isStatic) {
+            type = STATIC_METHOD;
+          }
           returnType = this._getType(methodValue.returnType || 'void');
           argumentTypes = (methodValue.argumentTypes || []).map(name => this._getType(name));
           impl = methodValue.implementation;
@@ -479,7 +484,7 @@ class ClassFactory {
         const argumentTypeNames = argumentTypes.map(t => t.name);
         const signature = '(' + argumentTypeNames.join('') + ')' + returnTypeName;
 
-        dexMethods.push([name, returnTypeName, argumentTypeNames, thrownTypeNames]);
+        dexMethods.push([name, returnTypeName, argumentTypeNames, thrownTypeNames, (type == STATIC_METHOD) ? kAccStatic : 0]);
         implMethods.push([name, signature, type, returnType, argumentTypes, impl]);
       });
 

--- a/lib/class-factory.js
+++ b/lib/class-factory.js
@@ -484,7 +484,7 @@ class ClassFactory {
         const argumentTypeNames = argumentTypes.map(t => t.name);
         const signature = '(' + argumentTypeNames.join('') + ')' + returnTypeName;
 
-        dexMethods.push([name, returnTypeName, argumentTypeNames, thrownTypeNames, (type == STATIC_METHOD) ? kAccStatic : 0]);
+        dexMethods.push([name, returnTypeName, argumentTypeNames, thrownTypeNames, (type === STATIC_METHOD) ? kAccStatic : 0]);
         implMethods.push([name, signature, type, returnType, argumentTypes, impl]);
       });
 

--- a/lib/mkdex.js
+++ b/lib/mkdex.js
@@ -530,7 +530,7 @@ function computeModel (classes) {
     }
 
     klass.methods.forEach(method => {
-      const [methodName, retType, argTypes, thrownTypes = []] = method;
+      const [methodName, retType, argTypes, thrownTypes = [], accessFlags] = method;
 
       strings.add(methodName);
 
@@ -563,13 +563,13 @@ function computeModel (classes) {
         strings.add('value');
       }
 
-      methods.push([klass.name, protoId, methodName, throwsAnnotationId]);
+      methods.push([klass.name, protoId, methodName, throwsAnnotationId, accessFlags]);
 
       if (methodName === '<init>') {
         superConstructors.add(name + '|' + protoId);
         const superConstructorId = superClass + '|' + protoId;
         if (javaConstructors.has(name) && !superConstructors.has(superConstructorId)) {
-          methods.push([superClass, protoId, methodName, null]);
+          methods.push([superClass, protoId, methodName, null, 0]);
           superConstructors.add(superConstructorId);
         }
       }
@@ -658,12 +658,13 @@ function computeModel (classes) {
   fieldItems.sort(compareFieldItems);
 
   const methodItems = methods.map(method => {
-    const [klass, protoId, name, annotationsId] = method;
+    const [klass, protoId, name, annotationsId, accessFlags] = method;
     return [
       typeToIndex[klass],
       protoToIndex[protoId],
       stringToIndex[name],
-      annotationsId
+      annotationsId,
+      accessFlags
     ];
   });
   methodItems.sort(compareMethodItems);
@@ -719,9 +720,9 @@ function computeModel (classes) {
     const sourceFileIndex = stringToIndex[klass.sourceFileName];
 
     const classMethods = methodItems.reduce((result, method, index) => {
-      const [holder, protoIndex, name, annotationsId] = method;
+      const [holder, protoIndex, name, annotationsId, accessFlags] = method;
       if (holder === classIndex) {
-        result.push([index, name, annotationsId, protoIndex]);
+        result.push([index, name, annotationsId, protoIndex, accessFlags]);
       }
       return result;
     }, []);
@@ -771,8 +772,8 @@ function computeModel (classes) {
       });
     const virtualMethods = compressClassMethodIndexes(classMethods
       .filter(([, name]) => name !== constructorNameIndex)
-      .map(([index]) => {
-        return [index, kAccPublic | kAccNative];
+      .map(([index, , , , accessFlags]) => {
+        return [index, accessFlags | kAccPublic | kAccNative];
       }));
 
     const classData = {


### PR DESCRIPTION
With this PR, `registerClass` supports static methods. This also fixes the bug of not being able to implement static interface methods or static superClass methods.

`mkdex` now has the ability to add additional access flags like `ACC_STATIC` to non-constructor methods https://source.android.com/docs/core/runtime/dex-format#access-flags

To make a static method, add `isStatic: true` in the method object:
```js
Java.scheduleOnMainThread(() => 
{
  Java.registerClass({
    name: 'com.example.MyWeirdTrustManager',
    superClass: SomeBaseClass,
    implements: [X509TrustManager],
    fields: {},
    methods: {
      checkServerTrusted: [{
        isStatic: true,
        returnType: 'void',
        argumentTypes: ['[Ljava.security.cert.X509Certificate;', 'java.lang.String'],
        implementation(chain, authType) {
          console.log('checkServerTrusted A');
        }
      }],
    }
  }
});
```

I leave it up to you to update the docs and unit tests.

For some reason, when registering a class with static methods from the app start (`frida -f`) it has to be scheduled on the main thread. Otherwise there will be this error:

```
Error: java.lang.ClassNotFoundException: Didn't find class "com.example.MyWeirdTrustManager" on path: DexPathList[[],nativeLibraryDirectories=[/system/lib, /system_ext/lib]]
    at t.throwIfExceptionPending (frida/node_modules/frida-java-bridge/lib/env.js:124:1)
    at Proxy.<anonymous> (frida/node_modules/frida-java-bridge/lib/class-factory.js:502:1)
    at Proxy.value (frida/node_modules/frida-java-bridge/lib/class-factory.js:949:1)
    at Proxy.value (frida/node_modules/frida-java-bridge/lib/class-factory.js:954:1)
    at I._make (frida/node_modules/frida-java-bridge/lib/class-factory.js:165:1)
    at I.use (frida/node_modules/frida-java-bridge/lib/class-factory.js:62:1)
    at I.registerClass (frida/node_modules/frida-java-bridge/lib/class-factory.js:275:1)
    at _.registerClass (frida/node_modules/frida-java-bridge/index.js:283:1)
```

This would also require a MethodSpec ts type update. Not sure if it is autogenerated