### PR TITLE
Fix JNI ERROR

### DIFF
--- a/index.js
+++ b/index.js
@@ -222,7 +222,6 @@ class Runtime {
         try {
           const className = env.getClassName(handle);
           callbacks.onMatch(className, handle);
-          env.deleteGlobalRef(handle);
           }
         finally {
           env.deleteGlobalRef(handle);

--- a/index.js
+++ b/index.js
@@ -219,9 +219,14 @@ class Runtime {
     withRunnableArtThread(vm, env, thread => {
       const collectClassHandles = makeArtClassVisitor(klass => {
         const handle = addGlobalReference(vmHandle, thread, klass);
-        const className = env.getClassName(handle);
-        callbacks.onMatch(className, handle);
-        env.deleteGlobalRef(handle);
+        try {
+          const className = env.getClassName(handle);
+          callbacks.onMatch(className, handle);
+          env.deleteGlobalRef(handle);
+          }
+        finally {
+          env.deleteGlobalRef(handle);
+        }
         return true;
       });
 

--- a/index.js
+++ b/index.js
@@ -222,8 +222,7 @@ class Runtime {
         try {
           const className = env.getClassName(handle);
           callbacks.onMatch(className, handle);
-          }
-        finally {
+        } finally {
           env.deleteGlobalRef(handle);
         }
         return true;


### PR DESCRIPTION
After executing `Java.enumerateLoadedClassesSync()` on certain devices and within multiple apps I got this error:

> signal 6 (SIGABRT) error, with code -6 (SI_TKILL) and fault address --------. 
The abort message reads: "JNI ERROR (app bug): global reference table overflow (max=51200). 
Global reference table dump: Last 10 entries (of 51200):".

This solution tested in several devices and work perfect.