### PR TITLE
android: Support new ART on compatible Android versions

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -151,6 +151,11 @@ function _getApi () {
     addLocalReference: null
   };
 
+  temporaryApi.isApiLevel34OrApexEquivalent = isArt && (
+    temporaryApi.find('_ZN3art7AppInfo29GetPrimaryApkReferenceProfileEv') !== null ||
+    temporaryApi.find('_ZN3art6Thread15RunFlipFunctionEPS0_') !== null
+  );
+
   const pending = isArt
     ? {
         functions: {
@@ -623,8 +628,7 @@ function _getArtRuntimeSpec (api) {
 
   const apiLevel = getAndroidApiLevel();
   const codename = getAndroidCodename();
-  const isApiLevel34OrApexEquivalent = api.find('_ZN3art7AppInfo29GetPrimaryApkReferenceProfileEv') !== null ||
-    api.find('_ZN3art6Thread15RunFlipFunctionEPS0_') !== null;
+  const { isApiLevel34OrApexEquivalent } = api;
 
   let spec = null;
 
@@ -1857,9 +1861,10 @@ function instrumentArtQuickEntrypoints (vm) {
 }
 
 function instrumentArtMethodInvocationFromInterpreter () {
+  const api = getApi();
+
   const apiLevel = getAndroidApiLevel();
-  const isApiLevel34OrApexEquivalent = getApi().find('_ZN3art7AppInfo29GetPrimaryApkReferenceProfileEv') !== null ||
-    getApi().find('_ZN3art6Thread15RunFlipFunctionEPS0_') !== null;
+  const { isApiLevel34OrApexEquivalent } = api;
 
   let artInterpreterDoCallExportRegex;
   if (apiLevel <= 22) {
@@ -1872,7 +1877,7 @@ function instrumentArtMethodInvocationFromInterpreter () {
     throw new Error('Unable to find method invocation in ART; please file a bug');
   }
 
-  const art = getApi().module;
+  const art = api.module;
   const entries = [...art.enumerateExports(), ...art.enumerateSymbols()].filter(entry => artInterpreterDoCallExportRegex.test(entry.name));
 
   if (entries.length === 0) {

--- a/lib/android.js
+++ b/lib/android.js
@@ -640,7 +640,7 @@ function _getArtRuntimeSpec (api) {
       if (apiLevel >= 33 || codename === 'Tiramisu' || isApiLevel34OrApexEquivalent) {
         classLinkerOffsets = [offset - (4 * pointerSize)];
         jniIdManagerOffset = offset - pointerSize;
-      } else if ((apiLevel >= 30 || codename === 'R') && !isApiLevel34OrApexEquivalent) {
+      } else if (apiLevel >= 30 || codename === 'R') {
         classLinkerOffsets = [offset - (3 * pointerSize), offset - (4 * pointerSize)];
         jniIdManagerOffset = offset - pointerSize;
       } else if (apiLevel >= 29) {

--- a/lib/android.js
+++ b/lib/android.js
@@ -633,10 +633,10 @@ function _getArtRuntimeSpec (api) {
     if (value.equals(vm)) {
       let classLinkerOffsets;
       let jniIdManagerOffset = null;
-      if (apiLevel >= 33 || codename === 'Tiramisu') {
+      if (apiLevel >= 33 || codename === 'Tiramisu' || isApiLevel34OrApexEquivalent) {
         classLinkerOffsets = [offset - (4 * pointerSize)];
         jniIdManagerOffset = offset - pointerSize;
-      } else if (apiLevel >= 30 || codename === 'R') {
+      } else if ((apiLevel >= 30 || codename === 'R') && !isApiLevel34OrApexEquivalent) {
         classLinkerOffsets = [offset - (3 * pointerSize), offset - (4 * pointerSize)];
         jniIdManagerOffset = offset - pointerSize;
       } else if (apiLevel >= 29) {
@@ -829,6 +829,7 @@ function _getArtInstrumentationSpec () {
     '4-28': 212,
     '4-29': 172,
     '4-30': 180,
+    '4-31': 180,
     '8-21': 224,
     '8-22': 224,
     '8-23': 296,
@@ -838,7 +839,8 @@ function _getArtInstrumentationSpec () {
     '8-27': 352,
     '8-28': 392,
     '8-29': 328,
-    '8-30': 336
+    '8-30': 336,
+    '8-31': 336
   };
 
   const deoptEnabledOffset = deoptimizationEnabledOffsets[`${pointerSize}-${getAndroidApiLevel()}`];
@@ -944,6 +946,8 @@ function tryGetArtClassLinkerSpec (runtime, runtimeSpec) {
 
   if (spec !== null) {
     cachedArtClassLinkerSpec = spec;
+  } else {
+    throw new Error('Unable to determine ClassLinker field offsets');
   }
 
   return spec;
@@ -1854,18 +1858,28 @@ function instrumentArtQuickEntrypoints (vm) {
 
 function instrumentArtMethodInvocationFromInterpreter () {
   const apiLevel = getAndroidApiLevel();
+  const isApiLevel34OrApexEquivalent = getApi().find('_ZN3art7AppInfo29GetPrimaryApkReferenceProfileEv') !== null ||
+    getApi().find('_ZN3art6Thread15RunFlipFunctionEPS0_') !== null;
 
   let artInterpreterDoCallExportRegex;
   if (apiLevel <= 22) {
     artInterpreterDoCallExportRegex = /^_ZN3art11interpreter6DoCallILb[0-1]ELb[0-1]EEEbPNS_6mirror9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtPNS_6JValueE$/;
-  } else if (apiLevel <= 33) {
+  } else if (apiLevel <= 33 && !isApiLevel34OrApexEquivalent) {
     artInterpreterDoCallExportRegex = /^_ZN3art11interpreter6DoCallILb[0-1]ELb[0-1]EEEbPNS_9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtPNS_6JValueE$/;
-  } else {
+  } else if (isApiLevel34OrApexEquivalent) {
     artInterpreterDoCallExportRegex = /^_ZN3art11interpreter6DoCallILb[0-1]EEEbPNS_9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtbPNS_6JValueE$/;
+  } else {
+    throw new Error('Unable to find method invocation in ART; please file a bug');
   }
 
   const art = getApi().module;
-  for (const entry of [...art.enumerateExports(), ...art.enumerateSymbols()].filter(entry => artInterpreterDoCallExportRegex.test(entry.name))) {
+  const entries = [...art.enumerateExports(), ...art.enumerateSymbols()].filter(entry => artInterpreterDoCallExportRegex.test(entry.name));
+
+  if (entries.length === 0) {
+    throw new Error('Unable to find method invocation in ART; please file a bug');
+  }
+
+  for (const entry of entries) {
     Interceptor.attach(entry.address, artController.hooks.Interpreter.doCall);
   }
 }


### PR DESCRIPTION
Recent versions of ART can run on older Android versions. Because some of the ClassLinker’s specifications and method-invocation logic are tied exclusively to the API level, this pull request also considers the ART level to ensure compatibility