### PR TITLE
fix handling conditional branch when recompiling for arm32

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -4256,6 +4256,7 @@ function recompileExceptionClearForArm (buffer, pc, exceptionClearImpl, nextFunc
         case 'beq.w':
         case 'beq':
         case 'bne':
+        case 'bne.w':
         case 'bgt':
           branchTarget = ptr(insn.operands[0].value);
           break;
@@ -4349,6 +4350,10 @@ function recompileExceptionClearForArm (buffer, pc, exceptionClearImpl, nextFunc
           break;
         case 'beq.w':
           writer.putBCondLabelWide('eq', branchLabelFromOperand(insn.operands[0]));
+          keep = false;
+          break;
+        case 'bne.w':
+          writer.putBCondLabelWide('ne', branchLabelFromOperand(insn.operands[0]));
           keep = false;
           break;
         case 'beq':


### PR DESCRIPTION
bne.w instruction is now handled in arm recompile routine resulting in successful art thread state transition for cases where this instruction appears in the code being recompiled.