### PR TITLE
Fixing issue #333 with JDK17 method replacement

### DIFF
--- a/lib/jvm.js
+++ b/lib/jvm.js
@@ -763,7 +763,7 @@ function nativeJvmMethod (method, impl, thread) {
   if (api.version >= 17) {
     // Only certain JDK versions of restore_unshareable_info() call
     // link_method(). Manually call if necessary.
-    let methodHandle = Memory.alloc(2 * pointerSize);
+    const methodHandle = Memory.alloc(2 * pointerSize);
     methodHandle.writePointer(newMethod.method);
     methodHandle.add(pointerSize).writePointer(thread);
     api['Method::link_method'](newMethod.method, methodHandle, thread);

--- a/lib/jvm.js
+++ b/lib/jvm.js
@@ -105,6 +105,7 @@ function _getApi () {
           _ZN6Method24restore_unshareable_infoEP10JavaThread: ['Method::restore_unshareable_info', 'void', ['pointer', 'pointer']],
           // JDK < 17
           _ZN6Method24restore_unshareable_infoEP6Thread: ['Method::restore_unshareable_info', 'void', ['pointer', 'pointer']],
+          _ZN6Method11link_methodERK12methodHandleP10JavaThread: ['Method::link_method', 'void', ['pointer', 'pointer', 'pointer']],
           _ZN6Method10jmethod_idEv: ['Method::jmethod_id', 'pointer', ['pointer']],
           _ZN6Method10clear_codeEv: function (address) {
             const clearCode = new NativeFunction(address, 'void', ['pointer'], nativeFunctionOptions);
@@ -236,6 +237,7 @@ function _getApi () {
         optionals: [
           '_ZN6Method24restore_unshareable_infoEP10JavaThread',
           '_ZN6Method24restore_unshareable_infoEP6Thread',
+          '_ZN6Method11link_methodERK12methodHandleP10JavaThread',
           '_ZN6Method10clear_codeEv',
           '_ZN6Method10clear_codeEb',
 
@@ -757,6 +759,15 @@ function nativeJvmMethod (method, impl, thread) {
   api['Method::set_native_function'](newMethod.method, impl, 0);
 
   api['Method::restore_unshareable_info'](newMethod.method, thread);
+
+  if (api.version >= 17) {
+    // Only certain JDK versions of restore_unshareable_info() call
+    // link_method(). Manually call if necessary.
+    let methodHandle = Memory.alloc(2 * pointerSize);
+    methodHandle.writePointer(newMethod.method);
+    methodHandle.add(pointerSize).writePointer(thread);
+    api['Method::link_method'](newMethod.method, methodHandle, thread);
+  }
 
   return newMethod;
 }

--- a/lib/jvm.js
+++ b/lib/jvm.js
@@ -400,7 +400,7 @@ function makeThreadFromJniHelper (api) {
   if (tryParse !== undefined) {
     const vm = new VM(api);
     const findClassImpl = vm.perform(env => env.handle.readPointer().add(6 * pointerSize).readPointer());
-    offset = parseInstructionsAt(findClassImpl, tryParse, { limit: 10 });
+    offset = parseInstructionsAt(findClassImpl, tryParse, { limit: 11 });
   }
 
   if (offset === null) {


### PR DESCRIPTION
Patch to fix the issue with replacing JDK17 methods. See https://github.com/frida/frida-java-bridge/issues/333 for the full details.