### PR TITLE
revert unnecessary error throwing

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -950,8 +950,6 @@ function tryGetArtClassLinkerSpec (runtime, runtimeSpec) {
 
   if (spec !== null) {
     cachedArtClassLinkerSpec = spec;
-  } else {
-    throw new Error('Unable to determine ClassLinker field offsets');
   }
 
   return spec;


### PR DESCRIPTION
reverted unnecessary error throwing from PR [#343](https://github.com/frida/frida-java-bridge/pull/343) that caused inoperability on some Android 12 devices.

Related issues: https://github.com/frida/frida-java-bridge/issues/347