### PR TITLE
Fix wrapper alloc

### DIFF
--- a/lib/class-factory.js
+++ b/lib/class-factory.js
@@ -899,7 +899,7 @@ Object.defineProperties(Wrapper.prototype, {
   $alloc: {
     enumerable: true,
     get () {
-      return this[Symbol.for('$alloc')];
+      return this[Symbol.for('alloc')];
     }
   },
   [Symbol.for('init')]: {


### PR DESCRIPTION
While migrating to using symbols, I migrated alloc with a wrong name.

Fixes #353