### PR TITLE
Fix system_server crashes - automatically detect offsets for ART class spec

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -956,43 +956,149 @@ function tryGetArtClassLinkerSpec (runtime, runtimeSpec) {
 }
 
 export function getArtClassSpec (vm) {
-  let apiLevel;
-  try {
-    apiLevel = getAndroidApiLevel();
-  } catch (e) {
-    return null;
-  }
+  const MAX_OFFSET = 0x100;
 
-  if (apiLevel >= 36) {
-    return {
-      offset: {
-        ifields: 0x28,
-        methods: 0x28 + 0x8,
-        sfields: 0,
-        copiedMethodsOffset: 0x6c,
-      }
+  let spec = null;
+
+  vm.perform(env => {
+    const fieldSpec = getArtFieldSpec(vm);
+    const methodSpec = getArtMethodSpec(vm);
+
+    const fInfo = {
+      artArrayLengthSize: 4,
+      artArrayEntrySize: fieldSpec.size,
+      // java/lang/Integer has 11 fields on Android 16.
+      artArrayMax: 20 
+    }
+
+    const mInfo = {
+      artArrayLengthSize: pointerSize,
+      artArrayEntrySize: methodSpec.size,
+      // java/lang/Integer has 66 methods on Android 16. methods on Android 16.
+      artArrayMax: 100
     };
-  } else if (apiLevel >= 26) {
-    return {
-      offset: {
-        ifields: 0x28,
-        methods: 0x28 + 0x8,
-        sfields: 0x28 + 0x10,
-        copiedMethodsOffset: 0x74,
+
+    // Read art array from memory.
+    const readArtArrray = (object_base, field_offset, length_size) => {
+      const header = object_base.add(field_offset).readPointer();
+      if (header.isNull()) {
+        return null;
       }
-    };
-  } else if (apiLevel >= 24) {
-    return {
-      offset: {
-        ifields: 0x38,
-        methods: 0x38 + 0x8,
-        sfields: 0x38 + 0x10,
-        copiedMethodsOffset: 0x7c,
+
+      const length = length_size == 4 ? header.readU32() : header.readU64();
+      if (length === 0) {
+        return null;
       }
+      
+      return {
+        length,
+        data: header.add(length_size)
+      };
     };
-  } else {
-    return null;
-  }
+
+    // Check if art array has a field.
+    const hasEntry = (object_base, offset, needle, info) => {
+      try {
+        const artArray = readArtArrray(object_base, offset, info.artArrayLengthSize);
+        if (artArray === null) {
+          return false;
+        }
+
+        for (let i = 0; i < Math.min(artArray.length, info.artArrayMax); i++) {
+          const fieldPtr = artArray.data.add(i * info.artArrayEntrySize);
+          if (fieldPtr.equals(needle)) {
+            return true;
+          }
+        }
+      } catch {
+        // ignore.
+      }
+
+      return false;
+    };
+
+    const clazz = env.findClass('java/lang/Integer');
+    const clazzRef = env.newGlobalRef(clazz);
+
+    try {
+      // Obtain object to investigate.
+      let object;
+  
+      withRunnableArtThread(vm, env, thread => {
+        object = getApi()['art::JavaVMExt::DecodeGlobal'](vm, thread, clazzRef);
+      });
+  
+      // Find fields.
+      const fieldInstance = env.getFieldId(clazzRef, 'value', 'I');
+      const fieldStatic = env.getStaticFieldId(clazzRef, 'TYPE', 'Ljava/lang/Class;');
+
+      let offsetInstance = -1;
+      let offsetStatic = -1;
+      
+      for (let offset = 0; offset < MAX_OFFSET; offset += 4) {
+        if (offsetInstance === -1 && hasEntry(object, offset, fieldInstance, fInfo)) {
+          offsetInstance = offset;
+        }
+
+        if (offsetStatic === -1 && hasEntry(object, offset, fieldStatic, fInfo)) {
+          offsetStatic = offset;
+        }
+      }
+
+      if (offsetInstance === -1 || offsetStatic === -1) {
+        throw new Error('Unable to find fields in java/lang/Integer; please file a bug');
+      }
+
+      const ifieldOffset = offsetInstance;
+      const sfieldOffset = offsetInstance != offsetStatic ? offsetStatic : 0;
+
+      // Find methods.
+      const methodInstance = env.getMethodId(clazzRef, 'intValue', '()I');
+
+      let offsetMethods = -1;
+
+      for (let offset = 0; offset < MAX_OFFSET; offset += 4) {
+        if (offsetMethods === -1 && hasEntry(object, offset, methodInstance, mInfo)) {
+          offsetMethods = offset;
+        }
+      }
+
+      if (offsetMethods === -1) {
+        throw new Error('Unable to find methods in java/lang/Integer; please file a bug');
+      }
+
+      // Find copied methods.
+      let offsetCopiedMethods = -1;
+
+      const methodsArray = readArtArrray(object, offsetMethods, mInfo.artArrayLengthSize);
+      const methodsArraySize = methodsArray.length;
+
+      for (let offset = offsetMethods; offset < MAX_OFFSET; offset += 4) {
+        if (object.add(offset).readU16() == methodsArraySize) {
+          offsetCopiedMethods = offset;
+          break;
+        }
+      }
+
+      if (offsetCopiedMethods === -1) {
+        throw new Error('Unable to find copied methods in java/lang/Integer; please file a bug');
+      }
+
+      spec = {
+        offset: {
+          ifields: ifieldOffset,
+          methods: offsetMethods,
+          sfields: sfieldOffset,
+          copiedMethodsOffset: offsetCopiedMethods,
+        }
+      };
+    } finally {
+      env.deleteLocalRef(clazz);
+      env.deleteGlobalRef(clazzRef);
+    }
+  });
+
+  return spec;
 }
 
 function _getArtMethodSpec (vm) {


### PR DESCRIPTION
This PR requires a new Frida build because it affects the internal system_server agent.

Closes
- https://github.com/frida/frida/issues/3533
  - https://github.com/frida/frida/issues/3525
  - https://github.com/frida/frida/issues/3527
  - https://github.com/frida/frida-core/issues/1165
  - https://github.com/ViRb3/magisk-frida/issues/62
 
---

As you can see this is a widespread issue. 

The issue is that the current code only accounts for the ART class layout based on the android sdk.
However, `libart.so` is shipped with the google security updates, that way you can have an Android 16 layout on Android 15.
This is why `pm uninstall com.google.android.art` is a "fix", although temporarily.

I fixes this by automatically detecting the offsets for the art class spec. By using a known class `java/lang/Integer` we can search for known fields / methods and find the necessary offsets that way.