### PR TITLE
Use stable fields for ART class spec offset detection

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -985,7 +985,7 @@ export function getArtClassSpec (vm) {
       }
 
       const length = (lengthSize === 4) ? header.readU32() : header.readU64().valueOf();
-      if (length === 0) {
+      if (length <= 0) {
         return null;
       }
 
@@ -1002,7 +1002,8 @@ export function getArtClassSpec (vm) {
           return false;
         }
 
-        for (let i = 0; i !== Math.max(0, Math.min(artArray.length, info.artArrayMax)); i++) {
+        const artArrayEnd = Math.min(artArray.length, info.artArrayMax);
+        for (let i = 0; i !== artArrayEnd; i++) {
           const fieldPtr = artArray.data.add(i * info.artArrayEntrySize);
           if (fieldPtr.equals(needle)) {
             return true;

--- a/lib/android.js
+++ b/lib/android.js
@@ -1002,7 +1002,7 @@ export function getArtClassSpec (vm) {
           return false;
         }
 
-        for (let i = 0; i !== Math.min(artArray.length, info.artArrayMax); i++) {
+        for (let i = 0; i !== Math.max(0, Math.min(artArray.length, info.artArrayMax)); i++) {
           const fieldPtr = artArray.data.add(i * info.artArrayEntrySize);
           if (fieldPtr.equals(needle)) {
             return true;

--- a/lib/android.js
+++ b/lib/android.js
@@ -967,14 +967,14 @@ export function getArtClassSpec (vm) {
     const fInfo = {
       artArrayLengthSize: 4,
       artArrayEntrySize: fieldSpec.size,
-      // java/lang/Integer has 11 fields on Android 16.
-      artArrayMax: 20
+      // java/io/File has 15 fields on Android 16.
+      artArrayMax: 25
     };
 
     const mInfo = {
       artArrayLengthSize: pointerSize,
       artArrayEntrySize: methodSpec.size,
-      // java/lang/Integer has 66 methods on Android 16.
+      // java/io/File has 63 methods on Android 16.
       artArrayMax: 100
     };
 
@@ -1014,7 +1014,7 @@ export function getArtClassSpec (vm) {
       return false;
     };
 
-    const clazz = env.findClass('java/lang/Integer');
+    const clazz = env.findClass('java/io/File');
     const clazzRef = env.newGlobalRef(clazz);
 
     try {
@@ -1023,8 +1023,8 @@ export function getArtClassSpec (vm) {
         object = getApi()['art::JavaVMExt::DecodeGlobal'](vm, thread, clazzRef);
       });
 
-      const fieldInstance = env.getFieldId(clazzRef, 'value', 'I');
-      const fieldStatic = env.getStaticFieldId(clazzRef, 'TYPE', 'Ljava/lang/Class;');
+      const fieldInstance = env.getFieldId(clazzRef, 'path', 'Ljava/lang/String;');
+      const fieldStatic = env.getStaticFieldId(clazzRef, 'separatorChar', 'C');
 
       let offsetStatic = -1;
       let offsetInstance = -1;
@@ -1037,20 +1037,20 @@ export function getArtClassSpec (vm) {
         }
       }
       if (offsetInstance === -1 || offsetStatic === -1) {
-        throw new Error('Unable to find fields in java/lang/Integer; please file a bug');
+        throw new Error('Unable to find fields in java/io/File; please file a bug');
       }
       const sfieldOffset = (offsetInstance !== offsetStatic) ? offsetStatic : 0;
       const ifieldOffset = offsetInstance;
 
       let offsetMethods = -1;
-      const methodInstance = env.getMethodId(clazzRef, 'intValue', '()I');
+      const methodInstance = env.getMethodId(clazzRef, 'length', '()J');
       for (let offset = 0; offset !== MAX_OFFSET; offset += 4) {
         if (offsetMethods === -1 && hasEntry(object, offset, methodInstance, mInfo)) {
           offsetMethods = offset;
         }
       }
       if (offsetMethods === -1) {
-        throw new Error('Unable to find methods in java/lang/Integer; please file a bug');
+        throw new Error('Unable to find methods in java/io/File; please file a bug');
       }
 
       let offsetCopiedMethods = -1;
@@ -1063,7 +1063,7 @@ export function getArtClassSpec (vm) {
         }
       }
       if (offsetCopiedMethods === -1) {
-        throw new Error('Unable to find copied methods in java/lang/Integer; please file a bug');
+        throw new Error('Unable to find copied methods in java/io/File; please file a bug');
       }
 
       spec = {


### PR DESCRIPTION
Addresses crashes commented under the previous pull request https://github.com/frida/frida-java-bridge/pull/359.
These fields shouldn't be optimised away.

Edit: Also added an extra check for the art array length. Sometimes it would read a negative number when trying offsets, and it would infinitely loop.