### PR TITLE
Use more stable fields for ART class spec offset detection

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -967,14 +967,14 @@ export function getArtClassSpec (vm) {
     const fInfo = {
       artArrayLengthSize: 4,
       artArrayEntrySize: fieldSpec.size,
-      // java/io/File has 15 fields on Android 16.
-      artArrayMax: 25
+      // java/lang/Thread has 36 fields on Android 16.
+      artArrayMax: 50
     };
 
     const mInfo = {
       artArrayLengthSize: pointerSize,
       artArrayEntrySize: methodSpec.size,
-      // java/io/File has 63 methods on Android 16.
+      // java/lang/Thread has 79 methods on Android 16.
       artArrayMax: 100
     };
 
@@ -1015,7 +1015,7 @@ export function getArtClassSpec (vm) {
       return false;
     };
 
-    const clazz = env.findClass('java/io/File');
+    const clazz = env.findClass('java/lang/Thread');
     const clazzRef = env.newGlobalRef(clazz);
 
     try {
@@ -1024,8 +1024,8 @@ export function getArtClassSpec (vm) {
         object = getApi()['art::JavaVMExt::DecodeGlobal'](vm, thread, clazzRef);
       });
 
-      const fieldInstance = env.getFieldId(clazzRef, 'path', 'Ljava/lang/String;');
-      const fieldStatic = env.getStaticFieldId(clazzRef, 'separatorChar', 'C');
+      const fieldInstance = env.getFieldId(clazzRef, 'name', 'Ljava/lang/String;');
+      const fieldStatic = env.getStaticFieldId(clazzRef, 'MAX_PRIORITY', 'I');
 
       let offsetStatic = -1;
       let offsetInstance = -1;
@@ -1038,20 +1038,20 @@ export function getArtClassSpec (vm) {
         }
       }
       if (offsetInstance === -1 || offsetStatic === -1) {
-        throw new Error('Unable to find fields in java/io/File; please file a bug');
+        throw new Error('Unable to find fields in java/lang/Thread; please file a bug');
       }
       const sfieldOffset = (offsetInstance !== offsetStatic) ? offsetStatic : 0;
       const ifieldOffset = offsetInstance;
 
       let offsetMethods = -1;
-      const methodInstance = env.getMethodId(clazzRef, 'length', '()J');
+      const methodInstance = env.getMethodId(clazzRef, 'getName', '()Ljava/lang/String;');
       for (let offset = 0; offset !== MAX_OFFSET; offset += 4) {
         if (offsetMethods === -1 && hasEntry(object, offset, methodInstance, mInfo)) {
           offsetMethods = offset;
         }
       }
       if (offsetMethods === -1) {
-        throw new Error('Unable to find methods in java/io/File; please file a bug');
+        throw new Error('Unable to find methods in java/lang/Thread; please file a bug');
       }
 
       let offsetCopiedMethods = -1;
@@ -1064,7 +1064,7 @@ export function getArtClassSpec (vm) {
         }
       }
       if (offsetCopiedMethods === -1) {
-        throw new Error('Unable to find copied methods in java/io/File; please file a bug');
+        throw new Error('Unable to find copied methods in java/lang/Thread; please file a bug');
       }
 
       spec = {


### PR DESCRIPTION
Hopefully my last PR regarding this. Thanks to @ExternalAddress4401 for providing repro code https://github.com/frida/frida-java-bridge/pull/361#issuecomment-3104746127.

This instance field should not be optimised out, see android code comment https://android.googlesource.com/platform/libcore.git/+/android-4.2.2_r1/luni/src/main/java/java/lang/Thread.java#133.
> some of these are accessed directly by the VM; do not rename them