### PR TITLE
jvm: Fix frida-java-bridge compatibility with Linux OpenJDK 17 AMD64

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,9 +1,29 @@
 import { getApi as androidGetApi, getAndroidVersion } from './android.js';
 import { getApi as jvmGetApi } from './jvm.js';
-let getApi = androidGetApi;
-try {
-  getAndroidVersion();
-} catch (e) {
-  getApi = jvmGetApi;
+
+function detectEnvironment() {
+  const platform = Process.platform;
+
+  if (platform === 'windows') {
+    return jvmGetApi;
+  }
+
+  if (platform === 'linux') {
+    try {
+      const modules = Process.enumerateModules();
+      const hasAndroidRuntime = modules.some(m =>
+        (m.name === 'libart.so' || m.name === 'libdvm.so') &&
+        (m.path.includes('/system/') || m.path.includes('/apex/') || m.path.includes('/data/dalvik-cache'))
+      );
+
+      if (hasAndroidRuntime) {
+        return androidGetApi;
+      }
+    } catch (e) {
+    }
+  }
+  return jvmGetApi;
 }
+
+const getApi = detectEnvironment();
 export default getApi;

--- a/lib/class-model.js
+++ b/lib/class-model.js
@@ -1303,7 +1303,17 @@ function compileModule (env) {
 
   const artApi = javaApi.add(javaApiSize);
   const { vm } = env;
-  const artClass = getArtClassSpec(vm);
+  
+  let artClass = null;
+  const api = getApi();
+  if (api !== null && api.flavor === 'art') {
+    try {
+      artClass = getArtClassSpec(vm);
+    } catch (e) {
+      artClass = null;
+    }
+  }
+  
   if (artClass !== null) {
     const c = artClass.offset;
     const m = getArtMethodSpec(vm);


### PR DESCRIPTION
    This commit resolves the issue where frida-java-bridge failed to work on Linux OpenJDK 17 AMD64 environments due to incorrect Android runtime detection and unconditional Android-specific code execution.

    Root cause analysis:

    1. The environment detection logic in api.js was incorrectly identifying Linux JVM environments as Android due to fallback mechanisms.
    2. The compileModule function in class-model.js was unconditionally calling Android-specific functions (getArtClassSpec, getArtMethodSpec, getArtFieldSpec) regardless of the detected environment.

<img width="872" height="787" alt="image" src="https://github.com/user-attachments/assets/5f9c55b4-2292-4337-9f8b-51797f1879ce" />
