### PR TITLE
fix: script crash on ARM64 Android during runtime disposal

### DIFF
--- a/index.js
+++ b/index.js
@@ -592,6 +592,13 @@ function initFactoryFromLoadedApk (factory, apk) {
 }
 
 const runtime = new Runtime();
-Script.bindWeak(runtime, () => { runtime._dispose(); });
+
+Script.bindWeak(runtime, () => { 
+  if (Process.arch === 'arm64') {
+    Script.setImmediate(() => runtime._dispose());
+    return;
+  }
+  runtime._dispose();
+});
 
 export default runtime;


### PR DESCRIPTION
## Summary
Fixed a critical crash issue on ARM64 Android devices where Frida scripts would fail with "Failed to load script: the connection is closed" when calling [Java.perform()](cci:1://file:///f:/data/dev/frida/frida-java-bridge/index.js:364:2-388:3). Also refactored the runtime disposal logic for better code readability.

## Root Cause
On ARM64 Android devices, immediate runtime disposal in `Script.bindWeak` callback causes race conditions where the Java bridge connection is closed before Java.perform() callbacks complete execution. This results in script crashes with the error "Failed to load script: the connection is closed".

## Solution
- Use `Script.setImmediate()` for deferred runtime disposal on ARM64 architectures
- Keep immediate disposal for other architectures (no changes to existing behavior)

Tested
SamSung A51
Android 13