### PR TITLE
Allow for Runtime._instrumentation being pointer

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -800,7 +800,32 @@ function tryDetectInstrumentationPointer (api) {
 }
 
 function parsex86InstrumentationPointer (insn) {
-  return null;
+  if (insn.mnemonic !== 'mov') {
+    return null;
+  }
+
+  const ops = insn.operands;
+
+  const dst = ops[0];
+  if (dst.value !== 'rax') {
+    return null;
+  }
+
+  const src = ops[1];
+  if (src.type !== 'mem') {
+    return null;
+  }
+
+  const mem = src.value;
+  if (mem.base !== 'rdi') {
+    return null;
+  }
+
+  const offset = mem.disp;
+  if (offset < 0x100 || offset > 0x400) {
+    return null;
+  }
+  return offset;
 }
 
 function parseArmInstrumentationPointer (insn) {


### PR DESCRIPTION
The instrumentation field in the Runtime class in some android 15 and all android 16 is now a pointer.
https://android.googlesource.com/platform/art/+/17c7ed2de734cf892b005b1d15b3db9855506f14

This should fix #368 

arm64
```
sub     sp, sp, #0x40
stp     fp, lr, [sp, #0x20]
stp     x20, x19, [sp, #0x30]
add     fp, sp, #0x20
mrs     x20, tpidr_el0
mov     x19, x0
adrp    x9, 0xe19000
add     x9, x9, #0xd98
ldr     x8, [x20, #0x28]
add     x1, sp, #0x8
stur    x8, [fp, #-0x8
ldr     x8, [x0, #0x328] <- picking this
ldr     x0, [x0, #0x258]
stp     x9, x8, [sp, #0x8]
```