### PR TITLE
Fix backtraces on Android 16

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -253,9 +253,8 @@ function _getApi () {
             this['art::StackVisitor::GetCurrentQuickFrameInfo'] = makeArtQuickFrameInfoGetter(address);
           },
 
+          _ZN3art7Context6CreateEv: ['art::Context::Create', 'pointer', []],
           _ZN3art6Thread18GetLongJumpContextEv: ['art::Thread::GetLongJumpContext', 'pointer', ['pointer']],
-
-          _ZN3art7Context6CreateEv: ['art::Context::Create', 'pointer', ['pointer']],
 
           _ZN3art6mirror5Class13GetDescriptorEPNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE: function (address) {
             this['art::mirror::Class::GetDescriptor'] = address;
@@ -354,6 +353,7 @@ function _getApi () {
           '_ZNK3art12StackVisitor9GetMethodEv',
           '_ZNK3art12StackVisitor16DescribeLocationEv',
           '_ZNK3art12StackVisitor24GetCurrentQuickFrameInfoEv',
+          '_ZN3art7Context6CreateEv',
           '_ZN3art6Thread18GetLongJumpContextEv',
           '_ZN3art6mirror5Class13GetDescriptorEPNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE',
           '_ZN3art6mirror5Class11GetLocationEv',
@@ -2536,7 +2536,7 @@ extern GumTlsKey current_backtrace;
 
 extern void (* perform_art_thread_state_transition) (JNIEnv * env);
 
-extern ArtContext * art_thread_get_long_jump_context (ArtThread * thread);
+extern ArtContext * art_make_context (ArtThread * thread);
 
 extern void art_stack_visitor_init (ArtStackVisitor * visitor, ArtThread * thread, void * context, StackWalkKind walk_kind,
     size_t num_frames, bool check_suspended);
@@ -2602,7 +2602,7 @@ _on_thread_state_transition_complete (ArtThread * thread)
     },
   };
 
-  context = art_thread_get_long_jump_context (thread);
+  context = art_make_context (thread);
 
   art_stack_visitor_init (&visitor, thread, context, STACK_WALK_SKIP_INLINED_FRAMES, 0, true);
   visitor.vtable = &visitor.vtable_storage;
@@ -2887,7 +2887,7 @@ std_string_get_data (StdString * str)
 `, {
     current_backtrace: Memory.alloc(Process.pointerSize),
     perform_art_thread_state_transition: performImpl,
-    art_thread_get_long_jump_context: api['art::Thread::GetLongJumpContext'] ?? api['art::Context::Create'],
+    art_make_context: api['art::Thread::GetLongJumpContext'] ?? api['art::Context::Create'],
     art_stack_visitor_init: api['art::StackVisitor::StackVisitor'],
     art_stack_visitor_walk_stack: api['art::StackVisitor::WalkStack'],
     art_stack_visitor_get_method: api['art::StackVisitor::GetMethod'],


### PR DESCRIPTION
Android [refactored](https://android.googlesource.com/platform/art/+/3ea38e1d3e11417bb7f86a5dcd24187c299dcd73%5E%21/#F0) backtraces breaking our assumptions. 
This follows the changes
```diff
-      context_(self->GetLongJumpContext()),
+      context_(Context::Create()),
```
from that refactor.