### PR TITLE
Fix for Process crash on accessing object["<init>"] with JVMTI available

### DIFF
--- a/lib/class-model.js
+++ b/lib/class-model.js
@@ -282,7 +282,8 @@ model_new (jclass class_handle,
       get_method_name (jvmti, method, &name, NULL, NULL);
       get_method_modifiers (jvmti, method, &modifiers);
 
-      model_add_method (model, name, method, modifiers);
+      if (name[0] != '<')
+        model_add_method (model, name, method, modifiers);
 
       deallocate (jvmti, name);
     }


### PR DESCRIPTION
Fixes crash that results from accessing wrongly exposed constructor when JVMTI is available. issue - #384