### PR TITLE
android: Fix crash when JdwpAdbState control socket pattern missing

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -4077,7 +4077,11 @@ class JdwpSession {
     acceptListener = Interceptor.attach(acceptImpl, function (args) {
       const state = args[0];
 
-      const controlSockPtr = Memory.scanSync(state.add(8252), 256, '00 ff ff ff ff 00')[0].address.add(1);
+      const matches = Memory.scanSync(state.add(8252), 256, '00 ff ff ff ff 00');
+      if (matches.length === 0) {
+        throw new Error('Unable to locate control socket pointer in JdwpAdbState at offset 8252');
+      }
+      const controlSockPtr = matches[0].address.add(1);
 
       /*
        * This will make JdwpAdbState::Accept() skip the control socket() and connect(),


### PR DESCRIPTION
The Memory.scanSync(...) result is now captured and length-checked before [0].address is dereferenced; on miss, it throws a descriptive error naming JdwpAdbState and the offset so layout drift is diagnosable.