### PR TITLE
class-factory: Throw clear error on unsupported Dalvik arch

### DIFF
--- a/lib/class-factory.js
+++ b/lib/class-factory.js
@@ -709,6 +709,8 @@ export default class ClassFactory {
           // Verified with 4.3.1 and 4.4.2
           pattern = '8d 64 24 d4 89 5c 24 1c 89 74 24 20 e8 ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? 85 d2';
           break;
+        default:
+          throw new Error('Unsupported architecture for Dalvik: ' + Process.arch);
       }
 
       Memory.scan(libdvm.base, libdvm.size, pattern, {

--- a/lib/class-factory.js
+++ b/lib/class-factory.js
@@ -709,6 +709,11 @@ export default class ClassFactory {
           // Verified with 4.3.1 and 4.4.2
           pattern = '8d 64 24 d4 89 5c 24 1c 89 74 24 20 e8 ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? 85 d2';
           break;
+        default:
+          throw new Error([
+            'Unsupported architecture',
+            'for Dalvik: ' + Process.arch
+          ].join(' '));
       }
 
       Memory.scan(libdvm.base, libdvm.size, pattern, {


### PR DESCRIPTION
The switch now throws a clear Unsupported architecture for Dalvik error instead of leaving pattern undefined and propagating a confusing failure into Memory.scan.