### PR TITLE
android: Fix GC hook installation on Android 16 (CMC + stripped libart)

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -12,6 +12,27 @@ import VM from './vm.js';
 const jsizeSize = 4;
 const pointerSize = Process.pointerSize;
 
+// Fallback for libart.so on Android 16, which is stripped (no .symtab)
+// but carries a .gnu_debugdata section. enumerateSymbols() parses that;
+// findExportByName / findSymbolByName do not.
+const debugdataSymbolCache = new WeakMap();
+function resolveDebugdataSymbol (module, name) {
+  let byName = debugdataSymbolCache.get(module);
+  if (byName === undefined) {
+    byName = new Map();
+    try {
+      for (const sym of module.enumerateSymbols()) {
+        if (!sym.address.isNull() && !byName.has(sym.name)) {
+          byName.set(sym.name, sym.address);
+        }
+      }
+    } catch (_) {
+    }
+    debugdataSymbolCache.set(module, byName);
+  }
+  return byName.get(name) ?? null;
+}
+
 const {
   readU32,
   readPointer,
@@ -145,6 +166,9 @@ function _getApi () {
       let address = module.findExportByName(name);
       if (address === null) {
         address = module.findSymbolByName(name);
+      }
+      if (address === null) {
+        address = resolveDebugdataSymbol(module, name);
       }
       return address;
     },
@@ -2137,9 +2161,8 @@ function instrumentArtMethodInvocationFromInterpreter () {
 
 function instrumentArtGarbageCollection () {
   const api = getApi();
-  const art = api.module;
 
-  const gc = art.findSymbolByName('_ZN3art2gc4Heap22CollectGarbageInternalENS0_9collector6GcTypeENS0_7GcCauseEbj');
+  const gc = api.find('_ZN3art2gc4Heap22CollectGarbageInternalENS0_9collector6GcTypeENS0_7GcCauseEbj');
   if (gc === null) {
     return;
   }
@@ -2159,9 +2182,8 @@ function instrumentArtFixupStaticTrampolines () {
     ['_ZN3art11ClassLinker26VisiblyInitializedCallback29AdjustThreadVisibilityCounterEPNS_6ThreadEl', '7f0f00f9 : 1ffcffff'],
   ];
   const api = getApi();
-  const art = api.module;
   for (const [name, pattern] of patterns) {
-    const base = art.findSymbolByName(name);
+    const base = api.find(name);
     if (base === null) {
       continue;
     }
@@ -2209,11 +2231,23 @@ function ensureArtKnowsHowToHandleReplacementMethods (vm) {
   const api = getApi();
   if (apiLevel > 28) {
     copyingPhase = api.find('_ZN3art2gc9collector17ConcurrentCopying12CopyingPhaseEv');
+    if (copyingPhase === null) {
+      // CopyingPhase can be inlined; RunPhases is the enclosing entry.
+      copyingPhase = api.find('_ZN3art2gc9collector17ConcurrentCopying9RunPhasesEv');
+    }
   } else if (apiLevel > 22) {
     copyingPhase = api.find('_ZN3art2gc9collector17ConcurrentCopying12MarkingPhaseEv');
   }
   if (copyingPhase !== null) {
     Interceptor.attach(copyingPhase, artController.hooks.Gc.copyingPhase);
+  }
+
+  // Android 16 defaults to Concurrent Mark Compact; attach the same
+  // synchronize-on-leave callback so entrypoints stay consistent across
+  // CMC cycles. See frida-java-bridge#387.
+  const markCompactRunPhases = api.find('_ZN3art2gc9collector11MarkCompact9RunPhasesEv');
+  if (markCompactRunPhases !== null) {
+    Interceptor.attach(markCompactRunPhases, artController.hooks.Gc.copyingPhase);
   }
 
   let runFlip = null;


### PR DESCRIPTION
Fixes #387.

On Android 16 (e.g. build `BP4A.251205.006`, `com.android.art@361302280`) the process crashes with a NULL dereference in `art::CodeInfo::DecodeGcMasksOnly` during a GC stack walk whenever a replacement `ArtMethod` is on some thread's stack when the collector runs. The reporter's backtrace in #387 shows the fault driven by `art::gc::collector::MarkCompact::RunPhases` → `VisitRoots` → `StackVisitor::WalkStack` → `DecodeGcMasksOnly`.

Two A16 libart.so changes together break the GC synchronization machinery in `ensureArtKnowsHowToHandleReplacementMethods` and `instrumentArtGarbageCollection`:

1. libart.so is now stripped — `.symtab` is gone but the library retains a `.gnu_debugdata` section (LZMA-compressed mini-debuginfo). `Module.findSymbolByName` reads `.dynsym` + `.symtab` and so returns `null` for `Heap::CollectGarbageInternal` and `ConcurrentCopying::CopyingPhase` on A16, silently skipping the hook install. `Module.enumerateSymbols()` does parse the mini-debuginfo, so the symbols are still reachable that way.

2. A16 defaults to **Concurrent Mark Compact** (CMC) instead of Concurrent Copying. Even if we resolve `ConcurrentCopying::CopyingPhase`, it never fires under CMC, so replacement `ArtMethod`s are never re-synchronized after compaction. `MarkCompact::RunPhases` is the CMC lifecycle-event equivalent.

## Changes

- Add a small `resolveDebugdataSymbol(module, name)` fallback that lazily caches `Module.enumerateSymbols()` per module, and plumb it into `temporaryApi.find` as a last resort after `findExportByName` / `findSymbolByName`. Same plumbing restores `Heap::CollectGarbageInternal` resolution transparently for all ART-symbol callers.
- Reroute the two raw `art.findSymbolByName(...)` call sites in `instrumentArtGarbageCollection` and `instrumentArtFixupStaticTrampolines` through `api.find` so they pick up the mini-debuginfo fallback.
- When `CopyingPhase` is inlined (also seen on A16+), fall back to `ConcurrentCopying::RunPhases` as the hook point — one level up in the same phase-driver function.
- Additionally hook `MarkCompact::RunPhases` with the existing `artController.hooks.Gc.copyingPhase` callback. The callback is collector-agnostic — it just synchronizes entrypoints at a "world is consistent again" lifecycle point — so reusing it for CMC is correct. Both hooks can coexist; only the active collector dispatches its phase.

Net diff: `lib/android.js` `+38 / −4`.

## Testing

Reproduced #387 on a Cuttlefish x86_64 guest running `aosp-android-latest-release` (build `15150359`, API 36, same libart BuildId class as the Pixel 7 reporter's build). Unpatched 7.0.13: HeapTaskDaemon SIGSEGV within seconds of attaching a `.implementation` hook to any hot constructor (e.g. `java.net.URL.<init>(String)` or `java.io.File.<init>(String)`).

With this patch applied, the following hook set runs to completion simultaneously on the same target for a full 90s analysis window:

- `.implementation` swaps on `java.net.URL.<init>(String)` and `java.io.File.<init>(String)`
- `.implementation` swaps on all 17 `java.lang.StringFactory.newString*` overloads
- `Interceptor.attach` on `art::mirror::String::AllocFromModifiedUtf8` (3 overloads) and `AllocFromUtf16`
- `Interceptor.attach` on libc `__system_property_get`, `__system_property_find`, `open`, `fopen*`, `freopen*`, `stat`
- `Interceptor.attach` on libdl dynamic-loader exports
- `Interceptor.attach` on libart/libdexfile dex-retrieval paths

Observed: zero tombstones, no `DecodeGcMasksOnly` frames, full MITM / logcat / media / trace artifact set collected, hooks actively firing (600+ `__system_property_get` rewrites, 121 `File.<init>` callbacks, 60 `MessageDigest` callbacks in one run).

## Notes

- No behavior change on pre-A16 builds: the new MarkCompact lookup simply returns `null` there via `api.find`, and the mini-debuginfo fallback is a no-op when `findSymbolByName` already succeeds.
- `WeakMap`-keyed symbol cache so entries die with the module.
- Kept `Thread::RunFlipFunction` hook as-is — still exported, still correct on CC builds.